### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: Eiendom
+version: 3.0
+organization: Eiendom
+product: Sikkerhetsmetrikker
+repo_types: [InternalClient]
+platforms: [SKIP]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,38 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "frisk-frontend"
+  tags:
+  - "internal"
+spec:
+  type: "website"
+  lifecycle: "production"
+  owner: "skvis"
+  system: "sikkerhetsmetrikker"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_frisk-frontend"
+  title: "Security Champion frisk-frontend"
+spec:
+  type: "security_champion"
+  parent: "eiendom_security_champions"
+  members:
+  - "larsore"
+  children:
+  - "resource:frisk-frontend"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "frisk-frontend"
+  links:
+  - url: "https://github.com/kartverket/frisk-frontend"
+    title: "frisk-frontend på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_frisk-frontend"
+  dependencyOf:
+  - "component:frisk-frontend"


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 3.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 3.0`
- `organization: Eiendom`
- `product: Sikkerhetsmetrikker`
- `repo_types: [InternalClient]`
- `platforms: [SKIP]`

Videre oppdaterer denne PRen `catalog-info.yaml` for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.