### PR TITLE
Frisk prod/hent miljøvariabler

### DIFF
--- a/.github/workflows/skip-deploy.yml
+++ b/.github/workflows/skip-deploy.yml
@@ -12,8 +12,74 @@ env:
   ARGO_VERSION_FILE: image-url-frisk-frontend
 
 jobs:
-  build-prod:
+  build-dev:
     name: Build and push docker image for dev
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    outputs:
+      image_url: ${{ steps.setOutput.outputs.image_url }}
+
+    steps:
+      - name: Checkout code
+        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.commit_sha == '') }}
+        uses: actions/checkout@v4
+
+      - name: Checkout code
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit_sha == '' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout specific commit
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit_sha == '' }}
+        run: git checkout ${{ github.event.inputs.commit_sha }}
+
+      - name: Set tag
+        id: set-tag
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+            echo "image_tag=latest" >> $GITHUB_OUTPUT
+          else
+            echo "image_tag=prebuild-temp" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=sha,format=long
+            type=raw,value=${{ steps.set-tag.outputs.image_tag }}
+
+      - name: Build docker and push
+        id: build-docker
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: DockerfileForSkip
+          push: ${{ !github.event.pull_request.draft }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Set output with build values
+        id: setOutput
+        run: |
+          echo "image_url=${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}" >> $GITHUB_OUTPUT
+
+  build-prod:
+    name: Build and push docker image for prod
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -96,7 +162,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     if: ${{ github.ref == 'refs/heads/main' && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dev == 'true')) }}
-    needs: build-prod
+    needs: build-dev
     runs-on: ubuntu-latest
     environment:
       name: dev
@@ -116,7 +182,7 @@ jobs:
           token: ${{ steps.octo-sts.outputs.token }}
       - name: Update version
         run: |
-          echo "\"${{ needs.build-prod.outputs.image_url }}\"" > "env/atgcp1-dev/regelrett-main/${{ env.ARGO_VERSION_FILE }}"
+          echo "\"${{ needs.build-dev.outputs.image_url }}\"" > "env/atgcp1-dev/regelrett-main/${{ env.ARGO_VERSION_FILE }}"
           git config --global user.email "noreply@kartverket.no"
           git config --global user.name "Frisk CI"
           git commit -am "Update ${{ env.ARGO_VERSION_FILE }}"
@@ -145,7 +211,7 @@ jobs:
           token: ${{ steps.octo-sts.outputs.token }}
       - name: Update version
         run: |
-          echo "\"${{ needs.build-prod.outputs.image_url }}\"" > "env/atgcp1-dev/regelrett-main/${{ env.ARGO_VERSION_FILE }}"
+          echo "\"${{ needs.build-prod.outputs.image_url }}\"" > "env/atgcp1-prod/regelrett-main/${{ env.ARGO_VERSION_FILE }}"
           git config --global user.email "noreply@kartverket.no"
           git config --global user.name "Frisk CI"
           git commit -am "Update ${{ env.ARGO_VERSION_FILE }}"

--- a/.github/workflows/skip-deploy.yml
+++ b/.github/workflows/skip-deploy.yml
@@ -121,3 +121,32 @@ jobs:
           git config --global user.name "Frisk CI"
           git commit -am "Update ${{ env.ARGO_VERSION_FILE }}"
           git push
+
+  deploy-prod:
+    name: Deploy to prod
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dev == 'true')) }}
+    needs: build-prod
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+    permissions:
+      id-token: write
+    steps:
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        with:
+          scope: kartverket/skvis-apps
+          identity: frisk-frontend
+      - name: Checkout skvis-apps
+        uses: actions/checkout@v4
+        with:
+          repository: kartverket/skvis-apps
+          ref: main
+          token: ${{ steps.octo-sts.outputs.token }}
+      - name: Update version
+        run: |
+          echo "\"${{ needs.build-prod.outputs.image_url }}\"" > "env/atgcp1-dev/regelrett-main/${{ env.ARGO_VERSION_FILE }}"
+          git config --global user.email "noreply@kartverket.no"
+          git config --global user.name "Frisk CI"
+          git commit -am "Update ${{ env.ARGO_VERSION_FILE }}"
+          git push

--- a/DockerfileForSkip
+++ b/DockerfileForSkip
@@ -11,5 +11,6 @@ RUN bun run build:skip
 
 FROM nginx:1.19
 COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
+COPY ./nginx/main.js /etc/nginx/main.js
 COPY --from=build /react-app/dist /usr/share/nginx/html
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/main.js
+++ b/nginx/main.js
@@ -1,0 +1,13 @@
+function getConfig(r) {
+    var config = {    
+        clientId: process.env.VITE_CLIENT_ID,
+        authority: process.env.VITE_AUTHORITY,
+        redirect_uri: process.env.VITE_LOGIN_REDIRECT_URI,
+        backend_url: process.env.VITE_BACKEND_URL,
+        regelrett_frontend_url: process.env.VITE_REGELRETT_FRONTEND_URL
+    };
+    r.headersOut['Content-Type'] = 'application/json';
+    r.return(200, JSON.stringify(config));
+}
+
+export default { getConfig };

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,8 @@
+load_module modules/ngx_http_js_module.so;
+
+env HEI;
+env TEST;
+
 worker_processes  1;
 pid /tmp/nginx.pid;
 
@@ -16,6 +21,8 @@ http {
     uwsgi_temp_path /tmp/nginx_uwsgi_temp_path;
     scgi_temp_path /tmp/nginx_scgi_temp_path;
 
+  js_import main.js;
+
   server {
     listen 3000;
     server_name  localhost;
@@ -31,6 +38,10 @@ http {
 
     location / {
       try_files $uri $uri/ /index.html;
+    }
+
+    location = /getConfig {
+      js_content main.getConfig;
     }
   }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,8 +1,5 @@
 load_module modules/ngx_http_js_module.so;
 
-env HEI;
-env TEST;
-
 worker_processes  1;
 pid /tmp/nginx.pid;
 

--- a/src/components/function-info-view.tsx
+++ b/src/components/function-info-view.tsx
@@ -11,6 +11,7 @@ import {
 	Button,
 } from "@kvib/react";
 import { Metadata } from "./metadata/metadata";
+import { getregelrettFrontendUrl } from "@/config";
 
 type FunctionInfoViewProps = {
 	functionId: number;
@@ -82,7 +83,7 @@ export function FunctionInfoView({ functionId }: FunctionInfoViewProps) {
 							...(teamId && { teamId }),
 							redirect: redirectURL,
 						});
-						const path = `${import.meta.env.VITE_REGELRETT_FRONTEND_URL}/ny?${searchParams.toString()}`;
+						const path = `${getregelrettFrontendUrl()}/ny?${searchParams.toString()}`;
 						window.location.href = path;
 					}}
 				>

--- a/src/components/metadata/regelrett-link.tsx
+++ b/src/components/metadata/regelrett-link.tsx
@@ -1,3 +1,4 @@
+import { getregelrettFrontendUrl } from "@/config";
 import { Link } from "@kvib/react";
 
 export function RegelrettLink({
@@ -7,7 +8,7 @@ export function RegelrettLink({
 		redirectBackUrl: window.location.href,
 		redirectBackTitle: "Funksjonsregisteret",
 	});
-	const url = `${import.meta.env.VITE_REGELRETT_FRONTEND_URL}/context/${contextId}?${searchParams.toString()}`;
+	const url = `${getregelrettFrontendUrl()}/context/${contextId}?${searchParams.toString()}`;
 	return (
 		<Link
 			href={url}

--- a/src/components/metadata/regelrett-metadata.tsx
+++ b/src/components/metadata/regelrett-metadata.tsx
@@ -1,8 +1,9 @@
+import { getregelrettFrontendUrl } from "@/config";
 import { LinkMetadata } from "./link-metadata";
 
 export function RegelrettMetadata({
 	metadata: { key, contextId },
 }: { metadata: { key: string; contextId: string } }) {
-	const url = `${import.meta.env.VITE_REGELRETT_FRONTEND_URL}/context/${contextId}`;
+	const url = `${getregelrettFrontendUrl()}/context/${contextId}`;
 	return <LinkMetadata metadata={{ key, url }} />;
 }

--- a/src/components/schema-button.tsx
+++ b/src/components/schema-button.tsx
@@ -1,3 +1,4 @@
+import { getregelrettFrontendUrl } from "@/config";
 import { useFunction } from "@/hooks/use-function";
 import { Button } from "@kvib/react";
 import type { ButtonProps } from "@kvib/react";
@@ -34,7 +35,7 @@ export function SchemaButton({
 					redirectBackUrl: window.location.href,
 					redirectBackTitle: "Funksjonsregisteret",
 				});
-				const path = `${import.meta.env.VITE_REGELRETT_FRONTEND_URL}/ny?${searchParams.toString()}`;
+				const path = `${getregelrettFrontendUrl()}/ny?${searchParams.toString()}`;
 				window.location.href = path;
 			}}
 		>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,59 @@
+export let config: IConfig;
+
+export interface IConfig {
+	clientId: string;
+	authority: string;
+	redirect_uri: string;
+	backend_url: string;
+	regelrett_frontend_url: string;
+}
+
+const defaultConfig: IConfig = {
+	clientId: "3e09bdb6-734c-473e-ab69-1238057dfc5d",
+	authority:
+		"https://login.microsoftonline.com/7531b79e-fd42-4826-bff2-131d82c7b557/v2.0",
+	redirect_uri: "http://localhost:5173",
+	backend_url: "https://frisk-backend.fly.dev",
+	regelrett_frontend_url:
+		"https://regelrett-frontend-1024826672490.europe-north1.run.app",
+};
+
+export async function getConfig(): Promise<IConfig> {
+	console.log("getting config...");
+	try {
+		const response = await fetch("/getConfig");
+		const contentType = response.headers.get("Content-Type");
+		if (contentType?.includes("application/json")) {
+			return response.json() as Promise<IConfig>;
+		}
+		console.log("Response is not JSON, using default config");
+		return defaultConfig;
+	} catch (error) {
+		return defaultConfig;
+	}
+}
+
+export function setConfig(_config: IConfig | null) {
+	console.log("setting config...");
+	config = _config || defaultConfig;
+}
+
+export function getClientId() {
+	return config.clientId;
+}
+
+export function getAuthority() {
+	return config.authority;
+}
+
+export function getRedirectUri() {
+	return config.redirect_uri;
+}
+
+export function getBackendUrl() {
+	return config.backend_url;
+}
+
+export function getregelrettFrontendUrl() {
+	return config.regelrett_frontend_url;
+}

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -1,8 +1,9 @@
 import { array, number, object, string, type z } from "zod";
 import { msalInstance, scopes } from "./msal";
 import { InteractionRequiredAuthError } from "@azure/msal-browser";
+import { getBackendUrl } from "@/config";
 
-const BACKEND_URL = import.meta.env.VITE_BACKEND_URL ?? "http://localhost:8080";
+const BACKEND_URL = getBackendUrl() ?? "http://localhost:8080";
 
 async function getTokens() {
 	const accounts = msalInstance.getAllAccounts();

--- a/src/services/msal.ts
+++ b/src/services/msal.ts
@@ -1,4 +1,11 @@
 import {
+	getAuthority,
+	getClientId,
+	getConfig,
+	getRedirectUri,
+	setConfig,
+} from "@/config";
+import {
 	type Configuration,
 	type PopupRequest,
 	PublicClientApplication,
@@ -6,9 +13,12 @@ import {
 	type SsoSilentRequest,
 } from "@azure/msal-browser";
 
-export const clientId = import.meta.env.VITE_CLIENT_ID;
-const authority = import.meta.env.VITE_AUTHORITY;
-const redirectUri = import.meta.env.VITE_LOGIN_REDIRECT_URI;
+setConfig(null);
+const config = await getConfig();
+setConfig(config);
+export const clientId = getClientId();
+const authority = getAuthority();
+const redirectUri = getRedirectUri();
 
 if (!clientId) {
 	throw new Error("Client ID is not set");

--- a/src/services/msal.ts
+++ b/src/services/msal.ts
@@ -16,7 +16,8 @@ import {
 setConfig(null);
 const config = await getConfig();
 setConfig(config);
-export const clientId = getClientId();
+
+const clientId = getClientId();
 const authority = getAuthority();
 const redirectUri = getRedirectUri();
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,4 +11,9 @@ export default defineConfig({
 			"@": path.resolve(__dirname, "./src"),
 		},
 	},
+	esbuild: {
+		supported: {
+			"top-level-await": true,
+		},
+	},
 });


### PR DESCRIPTION
## Beskrivelse

🥅 Mål med PRen: 
Vi begynner å få veldig mange kjøremiljøer for appen (localhost, gcp, skip-dev, skip-prod). Kan ikke ha en .env-fil for hvert eneste kjøremiljø. Ønsker en mer dynamisk approach som kan både gjøre det smud å deploye til nye miljøer, men også gjør det fortsatt enkelt å sette opp og utvikle lokalt.

## Løsning
Henter ut config rett fra kjøremiljøet til nginx (som må settes i skip/gcp/fly eller hvor enn du kjører nginx fra)

🆕 Endring:
- Laget endepunkt i nginx som heter /getconfig, returnerer en json med clientId, tentatant, url osv.
- Dersom /getconfig ikke finnes (typisk når man kjører lokalt), bruk standard localhost verdier.
- Endret til å bruke config-verdier fremfor VITE_... som settes i build-time.

## 🧪 Testing
Sjekk at appen fungerer som før. Jeg er ikke helt sikker på om alt er som det skal. 

Mulig det kan gjøres på en annen måte i frontend (bruk av React context for eksempel).
