### PR TITLE
fix default team in edit mode

### DIFF
--- a/src/components/team-select.tsx
+++ b/src/components/team-select.tsx
@@ -6,7 +6,7 @@ import { Text, Skeleton, Select } from "@kvib/react";
 export function TeamSelect({
 	functionId,
 }: { functionId: number; edit?: boolean }) {
-	const { metadata } = useFunction(functionId);
+	const { metadata } = useFunction(functionId, { includeMetadata: true });
 	const { teams } = useUser();
 	const currentTeamValue = metadata.data?.find((m) => m.key === "team")?.value;
 	const { team: currentTeam } = useTeam(currentTeamValue);


### PR DESCRIPTION
🥅 Mål med PRen: 
Når man editer en funksjon så blir default team "velg team" i stedet for nåværende team

🆕 Endring:
metadata ble ikke lastet inn fordi det manglet `includeMetadata: true`. Det gjorde at hvis man prøvde å edite en funksjon som ikke var lastet inn, så var ikke teamet lastet inn heller. Hvis man i stedet selected funksjonen først og deretter editet så dukket riktig team opp. 

