### PR TITLE
add getValue function to config

### DIFF
--- a/frisk.config.ts
+++ b/frisk.config.ts
@@ -14,8 +14,8 @@ export const config: FriskConfig = {
 					value: team.id,
 				}));
 			},
-			getValue: async (value: string) => {
-				const team = await getTeam(value);
+			getValue: async (input) => {
+				const team = await getTeam(input.value);
 				return team.displayName;
 			},
 			selectMode: "multi",
@@ -44,7 +44,7 @@ type GeneralMetadataContent = {
 	key: string;
 	displayName: string;
 	inheritFromParent: boolean;
-	getValue?: (key: string, value: string) => Promise<string>;
+	getValue?: (input: { key: string; value: string }) => Promise<string>;
 };
 
 type GeneralRequiredMetadata = GeneralMetadataContent & {

--- a/frisk.config.ts
+++ b/frisk.config.ts
@@ -1,5 +1,5 @@
 import type { HTMLInputTypeAttribute } from "react";
-import { getMyMicrosoftTeams } from "@/services/backend";
+import { getMyMicrosoftTeams, getTeam } from "@/services/backend";
 
 export const config: FriskConfig = {
 	metadata: [
@@ -13,6 +13,10 @@ export const config: FriskConfig = {
 					name: team.displayName,
 					value: team.id,
 				}));
+			},
+			getValue: async (value: string) => {
+				const team = await getTeam(value);
+				return team.displayName;
 			},
 			selectMode: "multi",
 			showOn: "createAndUpdate",
@@ -40,6 +44,7 @@ type GeneralMetadataContent = {
 	key: string;
 	displayName: string;
 	inheritFromParent: boolean;
+	getValue?: (key: string, value: string) => Promise<string>;
 };
 
 type GeneralRequiredMetadata = GeneralMetadataContent & {

--- a/frisk.config.ts
+++ b/frisk.config.ts
@@ -6,7 +6,7 @@ export const config: FriskConfig = {
 		{
 			key: "team",
 			type: "select",
-			displayName: "Ansvarlig team for denne funksjonen?",
+			label: "Ansvarlig team for denne funksjonen?",
 			getOptions: async () => {
 				const teams = await getMyMicrosoftTeams();
 				return teams.map((team) => ({
@@ -14,7 +14,7 @@ export const config: FriskConfig = {
 					value: team.id,
 				}));
 			},
-			getValue: async (input) => {
+			getDisplayValue: async (input) => {
 				const team = await getTeam(input.value);
 				return team.displayName;
 			},
@@ -27,7 +27,7 @@ export const config: FriskConfig = {
 		{
 			key: "backstage-url",
 			type: "url",
-			displayName: "Lenke til utviklerportalen",
+			label: "Lenke til utviklerportalen",
 			showOn: "createAndUpdate",
 			isRequired: false,
 			placeholder: "Sett inn lenke",
@@ -42,9 +42,9 @@ type FriskConfig = {
 
 type GeneralMetadataContent = {
 	key: string;
-	displayName: string;
+	label: string;
 	inheritFromParent: boolean;
-	getValue?: (input: { key: string; value: string }) => Promise<string>;
+	getDisplayValue?: (input: { key: string; value: string }) => Promise<string>;
 };
 
 type GeneralRequiredMetadata = GeneralMetadataContent & {

--- a/src/components/function-column.tsx
+++ b/src/components/function-column.tsx
@@ -212,7 +212,7 @@ export function FunctionColumn({ functionId }: FunctionFolderProps) {
 
 								{config.metadata.map((meta) => (
 									<MetadataInput
-										key={meta.displayName}
+										key={meta.label}
 										metadata={meta}
 										parentFunctionId={functionId}
 										functionId={undefined}

--- a/src/components/function-column.tsx
+++ b/src/components/function-column.tsx
@@ -212,7 +212,7 @@ export function FunctionColumn({ functionId }: FunctionFolderProps) {
 
 								{config.metadata.map((meta) => (
 									<MetadataInput
-										key={meta.label}
+										key={meta.key}
 										metadata={meta}
 										parentFunctionId={functionId}
 										functionId={undefined}

--- a/src/components/metadata/metadata-input.tsx
+++ b/src/components/metadata/metadata-input.tsx
@@ -87,7 +87,7 @@ function SelectInput({
 					fontWeight: "medium",
 				}}
 			>
-				{metadata.displayName}
+				{metadata.label}
 			</FormLabel>
 			<Skeleton isLoaded={!options.isLoading} fitContent>
 				{options.isSuccess ? (
@@ -136,7 +136,7 @@ function InputField({ metadata, functionId, parentFunctionId }: InputProps) {
 	return (
 		<FormControl isRequired={metadata.isRequired}>
 			<FormLabel style={{ fontSize: "small", fontWeight: "medium" }}>
-				{metadata.displayName}
+				{metadata.label}
 			</FormLabel>
 			<Input
 				autoFocus


### PR DESCRIPTION
🥅 Mål med PRen:
Legge til en getValue funksjon i configen til metadata som kan brukes til visning av metadata. Den er optional for det er ikke alltid man trenger å "konvertere" det som skal være i visningen.
F.eks. på team så brukes den funksjonen til å gjøre om teamId til displayName.
