### PR TITLE
replace team and backstage in selected view with config

### DIFF
--- a/frisk.config.ts
+++ b/frisk.config.ts
@@ -16,7 +16,7 @@ export const config: FriskConfig = {
 			},
 			getDisplayValue: async (input) => {
 				const team = await getTeam(input.value);
-				return team.displayName;
+				return team.displayName.replace(/.* - /, "");
 			},
 			selectMode: "multi",
 			showOn: "createAndUpdate",
@@ -32,6 +32,9 @@ export const config: FriskConfig = {
 			isRequired: false,
 			placeholder: "Sett inn lenke",
 			inheritFromParent: false,
+			getDisplayValue: async () => {
+				return "Utviklerportalen";
+			},
 		},
 	],
 };

--- a/frisk.config.ts
+++ b/frisk.config.ts
@@ -16,7 +16,7 @@ export const config: FriskConfig = {
 			},
 			getDisplayValue: async (input) => {
 				const team = await getTeam(input.value);
-				return team.displayName.replace(/.* - /, "");
+				return team.displayName;
 			},
 			selectMode: "multi",
 			showOn: "createAndUpdate",

--- a/src/components/function-card-selected-view.tsx
+++ b/src/components/function-card-selected-view.tsx
@@ -2,7 +2,6 @@ import { Flex, Text, Skeleton, List, ListItem, Box, Stack } from "@kvib/react";
 import { SchemaButton } from "./schema-button";
 import { RegelrettLink } from "./metadata/regelrett-link";
 import { useFunction } from "@/hooks/use-function";
-import { useTeam } from "@/hooks/use-team";
 import { EditAndSelectButtons } from "./edit-and-select-buttons";
 import { config } from "../../frisk.config";
 import { MetadataView } from "./metadata/metadata-view";
@@ -14,14 +13,8 @@ export function FunctionCardSelectedView({
 		includeMetadata: true,
 		includeDependencies: true,
 	});
-	const teamId = metadata.data?.find((m) => m.key === "team")?.value;
-	const { team } = useTeam(teamId);
 	const schemaMetadata =
 		metadata.data?.filter((m) => m.key.startsWith("rr-")) ?? [];
-	const backstageMetadata =
-		metadata.data?.filter((m) => m.key.startsWith("backstage-url")) ?? [];
-	const teamDisplayName = team.data?.displayName.replace(/.* - /, "");
-	const teamLoaded = !metadata.isLoading && !team.isLoading;
 
 	return (
 		<Stack paddingLeft="10px" w="100%">

--- a/src/components/function-card-selected-view.tsx
+++ b/src/components/function-card-selected-view.tsx
@@ -3,8 +3,9 @@ import { SchemaButton } from "./schema-button";
 import { RegelrettLink } from "./metadata/regelrett-link";
 import { useFunction } from "@/hooks/use-function";
 import { useTeam } from "@/hooks/use-team";
-import { BackstageLink } from "./metadata/backstage-link";
 import { EditAndSelectButtons } from "./edit-and-select-buttons";
+import { config } from "../../frisk.config";
+import { MetadataView } from "./metadata/metadata-view";
 
 export function FunctionCardSelectedView({
 	functionId,
@@ -32,11 +33,8 @@ export function FunctionCardSelectedView({
 				</Skeleton>
 				<EditAndSelectButtons functionId={functionId} selected />
 			</Flex>
-			<Skeleton isLoaded={teamLoaded} fitContent>
-				<Text>{teamDisplayName ?? "<Ingen team>"}</Text>
-			</Skeleton>
-			{backstageMetadata.map((item) => (
-				<BackstageLink url={item.value} key={item.key} />
+			{config.metadata.map((meta) => (
+				<MetadataView key={meta.key} metadata={meta} functionId={functionId} />
 			))}
 			{dependencies.data && dependencies.data?.length > 0 && (
 				<Text fontSize="xs" fontWeight="700" mb="4px">

--- a/src/components/metadata/metadata-input.tsx
+++ b/src/components/metadata/metadata-input.tsx
@@ -79,8 +79,6 @@ function SelectInput({
 		queryFn: metadata.getOptions,
 	});
 
-	console.log("test", options.data);
-
 	return (
 		<FormControl isRequired={metadata.isRequired}>
 			<FormLabel

--- a/src/components/metadata/metadata-input.tsx
+++ b/src/components/metadata/metadata-input.tsx
@@ -75,9 +75,11 @@ function SelectInput({
 	)?.value;
 
 	const options = useQuery({
-		queryKey: [metadata],
+		queryKey: [metadata, "getOptions"],
 		queryFn: metadata.getOptions,
 	});
+
+	console.log("test", options.data);
 
 	return (
 		<FormControl isRequired={metadata.isRequired}>

--- a/src/components/metadata/metadata-view.tsx
+++ b/src/components/metadata/metadata-view.tsx
@@ -1,0 +1,91 @@
+import { useMetadata } from "@/hooks/use-metadata";
+import { Link, Skeleton, Text } from "@kvib/react";
+import { useQuery } from "@tanstack/react-query";
+import type { config } from "frisk.config";
+
+type Props = {
+	metadata: (typeof config.metadata)[number];
+	functionId: number | undefined;
+};
+
+export function MetadataView({ metadata, functionId }: Props) {
+	const { data: currentMetadata, isPending: isCurrentMetadataLoading } =
+		useMetadata(functionId);
+
+	const metadataToDisplay = currentMetadata?.find(
+		(m) => metadata.key === m.key,
+	);
+
+	functionId === 228 &&
+		console.log({ metadataToDisplay, currentMetadata, metadata });
+	const { data: displayValue, isPending: isDisplayValueLoading } = useQuery({
+		queryKey: [metadata, "getDisplayValue"],
+		queryFn: () => {
+			if (metadata.getDisplayValue)
+				// biome-ignore lint/style/noNonNullAssertion: <explanation>
+				return metadata.getDisplayValue(metadataToDisplay!);
+			// biome-ignore lint/style/noNonNullAssertion: <explanation>
+			return metadataToDisplay!.value;
+		},
+		enabled: !!metadataToDisplay,
+	});
+
+	const metadataType = metadata.type;
+	switch (metadataType) {
+		case "text":
+		case "number":
+		case "select":
+			return (
+				<TextView
+					displayValue={displayValue}
+					isLoading={isCurrentMetadataLoading && isDisplayValueLoading}
+				/>
+			);
+		case "url":
+			return (
+				<LinkView
+					url={metadataToDisplay?.value ?? ""}
+					displayValue={displayValue}
+				/>
+			);
+		default:
+			metadataType satisfies never;
+			console.error("Unsupported data type");
+			return null;
+	}
+}
+
+type TextViewProps = {
+	displayValue: string | undefined;
+	isLoading: boolean;
+};
+
+function TextView({ displayValue, isLoading }: TextViewProps) {
+	return (
+		<Skeleton isLoaded={!isLoading} fitContent>
+			<Text>{displayValue}</Text>
+		</Skeleton>
+	);
+}
+
+type LinkViewProps = {
+	url: string;
+	displayValue: string | undefined;
+};
+
+function LinkView({ url, displayValue }: LinkViewProps) {
+	return (
+		<Link
+			fontSize="sm"
+			fontWeight="700"
+			colorScheme="blue"
+			width="fit-content"
+			isExternal
+			href={url}
+			onClick={(e) => e.stopPropagation()}
+			marginBottom="10px"
+		>
+			{displayValue}
+		</Link>
+	);
+}

--- a/src/components/metadata/metadata-view.tsx
+++ b/src/components/metadata/metadata-view.tsx
@@ -16,8 +16,6 @@ export function MetadataView({ metadata, functionId }: Props) {
 		(m) => metadata.key === m.key,
 	);
 
-	functionId === 228 &&
-		console.log({ metadataToDisplay, currentMetadata, metadata });
 	const { data: displayValue, isPending: isDisplayValueLoading } = useQuery({
 		queryKey: [metadata, "getDisplayValue"],
 		queryFn: () => {
@@ -31,6 +29,8 @@ export function MetadataView({ metadata, functionId }: Props) {
 	});
 
 	const metadataType = metadata.type;
+	if (!metadataToDisplay && !isCurrentMetadataLoading) return null;
+
 	switch (metadataType) {
 		case "text":
 		case "number":
@@ -44,8 +44,9 @@ export function MetadataView({ metadata, functionId }: Props) {
 		case "url":
 			return (
 				<LinkView
-					url={metadataToDisplay?.value ?? ""}
+					url={metadataToDisplay?.value}
 					displayValue={displayValue}
+					isLoading={isCurrentMetadataLoading && isDisplayValueLoading}
 				/>
 			);
 		default:
@@ -69,23 +70,26 @@ function TextView({ displayValue, isLoading }: TextViewProps) {
 }
 
 type LinkViewProps = {
-	url: string;
+	url: string | undefined;
 	displayValue: string | undefined;
+	isLoading: boolean;
 };
 
-function LinkView({ url, displayValue }: LinkViewProps) {
+function LinkView({ url, displayValue, isLoading }: LinkViewProps) {
 	return (
-		<Link
-			fontSize="sm"
-			fontWeight="700"
-			colorScheme="blue"
-			width="fit-content"
-			isExternal
-			href={url}
-			onClick={(e) => e.stopPropagation()}
-			marginBottom="10px"
-		>
-			{displayValue}
-		</Link>
+		<Skeleton isLoaded={!isLoading} fitContent>
+			<Link
+				fontSize="sm"
+				fontWeight="700"
+				colorScheme="blue"
+				width="fit-content"
+				isExternal
+				href={url}
+				onClick={(e) => e.stopPropagation()}
+				marginBottom="10px"
+			>
+				{displayValue}
+			</Link>
+		</Skeleton>
 	);
 }


### PR DESCRIPTION
🥅 Mål med PRen:
Erstatte hardkoding av det som er på kortet i selected view med config.

🆕 Endring:
- Lagde MetadataView component i samme duren som MetadataInput
- Erstattet hardkoding av team og backstage-url med data fra config
