### PR TITLE
171 toogle close function

### DIFF
--- a/frisk.config.ts
+++ b/frisk.config.ts
@@ -72,6 +72,7 @@ export const config: FriskConfig = {
 			isRequired: false,
 			placeholder: "Sett inn skjema",
 			inheritFromParent: false,
+			isDeletable: true,
 			getDisplayValue: async (input) => {
 				const [contextId, tableName, __] = input.value.split(":splitTarget:");
 				const searchParams = new URLSearchParams({
@@ -175,10 +176,19 @@ type GeneralRequiredMetadata = GeneralMetadataContent & {
 
 type GeneralOptionalMetadata = GeneralMetadataContent & {
 	isRequired: false;
-	showOn: "update" | "createAndUpdate" | "readOnly";
+	showOn: "update" | "createAndUpdate";
 };
 
-type GeneralMetadata = GeneralRequiredMetadata | GeneralOptionalMetadata;
+type ReadOnlyMetadata = GeneralMetadataContent & {
+	isRequired: false;
+	showOn: "readOnly";
+	isDeletable: boolean;
+};
+
+type GeneralMetadata =
+	| GeneralRequiredMetadata
+	| GeneralOptionalMetadata
+	| ReadOnlyMetadata;
 
 export type SelectMetadata = GeneralMetadata & {
 	getOptions: () => Promise<SelectOption[]>;

--- a/frisk.config.ts
+++ b/frisk.config.ts
@@ -12,6 +12,7 @@ export const config: FriskConfig = {
 		{
 			key: "team",
 			type: "select",
+			title: "Team",
 			label: "Ansvarlig team for denne funksjonen?",
 			getOptions: async () => {
 				const teams = await getMyMicrosoftTeams();
@@ -51,6 +52,7 @@ export const config: FriskConfig = {
 		{
 			key: "backstage-url",
 			type: "url",
+			title: "Lenke til utviklerportalen",
 			isExternal: true,
 			label: "Lenke til utviklerportalen",
 			showOn: "createAndUpdate",

--- a/src/components/delete-metadata-modal.tsx
+++ b/src/components/delete-metadata-modal.tsx
@@ -1,0 +1,71 @@
+import { useMetadata } from "@/hooks/use-metadata";
+import {
+	Button,
+	HStack,
+	Modal,
+	ModalBody,
+	ModalContent,
+	ModalFooter,
+	ModalHeader,
+	ModalOverlay,
+	Stack,
+	Text,
+} from "@kvib/react";
+
+type Props = {
+	onOpen: () => void;
+	onClose: () => void;
+	isOpen: boolean;
+	functionId: number;
+	metadataId: number;
+	displayValue: string | undefined;
+};
+
+export function DeleteMetadataModal({
+	onClose,
+	isOpen,
+	functionId,
+	metadataId,
+	displayValue,
+}: Props) {
+	const { removeMetadata } = useMetadata(functionId);
+
+	return (
+		<Modal onClose={onClose} isOpen={isOpen} isCentered>
+			<ModalOverlay />
+			<ModalContent>
+				<ModalHeader>Slett {displayValue}</ModalHeader>
+				<ModalBody>
+					<Stack>
+						<Text size="sm">
+							Er du sikker på at du vil slette {displayValue}?
+						</Text>
+					</Stack>
+				</ModalBody>
+				<ModalFooter>
+					<HStack justifyContent="end">
+						<Button variant="tertiary" colorScheme="blue" onClick={onClose}>
+							Avbryt
+						</Button>
+						<Button
+							aria-label="Slett metadata"
+							variant="primary"
+							colorScheme="red"
+							leftIcon="delete"
+							onClick={async (e) => {
+								e.preventDefault();
+								removeMetadata.mutateAsync({
+									id: metadataId,
+									functionId: functionId,
+								});
+							}}
+							isLoading={removeMetadata.isPending}
+						>
+							Slett
+						</Button>
+					</HStack>
+				</ModalFooter>
+			</ModalContent>
+		</Modal>
+	);
+}

--- a/src/components/function-card.tsx
+++ b/src/components/function-card.tsx
@@ -47,7 +47,9 @@ export function FunctionCard({
 									!func?.data?.path.includes(path) &&
 									!path.includes(`${func?.data?.path}`),
 							),
-							`${func?.data?.path}`,
+							...(search.path.includes(`${func?.data?.path}`)
+								? [func?.data?.path.slice(0, func?.data?.path.lastIndexOf("."))]
+								: [`${func?.data?.path}`]),
 						],
 
 						edit: search.edit,

--- a/src/components/metadata/metadata-view.tsx
+++ b/src/components/metadata/metadata-view.tsx
@@ -1,7 +1,16 @@
 import { useMetadata } from "@/hooks/use-metadata";
-import { Box, Link, Skeleton, Text } from "@kvib/react";
+import {
+	Box,
+	Flex,
+	IconButton,
+	Link,
+	Skeleton,
+	Text,
+	useDisclosure,
+} from "@kvib/react";
 import { useQueries } from "@tanstack/react-query";
 import type { Metadata } from "../../../frisk.config";
+import { DeleteMetadataModal } from "../delete-metadata-modal";
 
 type Props = {
 	metadata: Metadata;
@@ -45,6 +54,7 @@ export function MetadataView({ metadata, functionId }: Props) {
 				const metadataDisplayType = dv.data?.displayOptions?.type;
 				const metadataType = metadata.type;
 				const metaDataValue = dv.data?.value ?? metadataToDisplay?.[i]?.value;
+				const metadataId = metadataToDisplay?.[i]?.id;
 				const isLoading = isCurrentMetadataLoading || isDisplayValueLoading;
 				const isNoMetadata = !currentMetadata && !isCurrentMetadataLoading;
 
@@ -66,6 +76,11 @@ export function MetadataView({ metadata, functionId }: Props) {
 								url={metaDataValue}
 								displayValue={displayValue}
 								isExternal={dv.data?.displayOptions?.isExternal ?? true}
+								isDeletable={
+									metadata.showOn === "readOnly" && metadata.isDeletable
+								}
+								metadataId={metadataId}
+								functionId={functionId}
 								isLoading={isLoading}
 							/>
 						);
@@ -98,6 +113,11 @@ export function MetadataView({ metadata, functionId }: Props) {
 										url={metaDataValue}
 										displayValue={displayValue}
 										isExternal={metadata.isExternal}
+										isDeletable={
+											metadata.showOn === "readOnly" && metadata.isDeletable
+										}
+										metadataId={metadataId}
+										functionId={functionId}
 										isLoading={isLoading}
 									/>
 								);
@@ -133,23 +153,57 @@ type LinkViewProps = {
 	url: string | undefined;
 	displayValue: string | undefined;
 	isExternal: boolean;
+	isDeletable: boolean;
+	metadataId: number | undefined;
+	functionId: number | undefined;
 	isLoading: boolean;
 };
 
-function LinkView({ url, displayValue, isExternal, isLoading }: LinkViewProps) {
+function LinkView({
+	url,
+	displayValue,
+	isExternal,
+	isDeletable,
+	metadataId,
+	functionId,
+	isLoading,
+}: LinkViewProps) {
+	const { isOpen, onOpen, onClose } = useDisclosure();
 	return (
 		<Skeleton isLoaded={!isLoading} fitContent>
-			<Link
-				fontSize="sm"
-				fontWeight="700"
-				colorScheme="blue"
-				width="fit-content"
-				isExternal={isExternal}
-				href={url}
-				onClick={(e) => e.stopPropagation()}
-			>
-				{displayValue ?? "<Ingen lenke>"}
-			</Link>
+			<Flex alignItems="center">
+				<Link
+					fontSize="sm"
+					fontWeight="700"
+					colorScheme="blue"
+					width="fit-content"
+					isExternal={isExternal}
+					href={url}
+					onClick={(e) => e.stopPropagation()}
+				>
+					{displayValue ?? "<Ingen lenke>"}
+				</Link>
+				{isDeletable && (
+					<IconButton
+						aria-label="delete"
+						icon="delete"
+						variant="tertiary"
+						size="sm"
+						color="black"
+						onClick={onOpen}
+					/>
+				)}
+				{functionId && metadataId && (
+					<DeleteMetadataModal
+						onOpen={onOpen}
+						onClose={onClose}
+						isOpen={isOpen}
+						functionId={functionId}
+						metadataId={metadataId}
+						displayValue={displayValue}
+					/>
+				)}
+			</Flex>
 		</Skeleton>
 	);
 }


### PR DESCRIPTION
## Beskrivelse

🥅 Mål med PRen: Ønkser å kunne "unseelecte"/"lukke" en funsjon som allerede er valgt ved å klikke på den.  

## Løsning

🆕 Endring: Endret navigation i card sin onclick: De eksiterende pathsene blir fjernet fra path listen og lagt til igjen, med mindre man klikker på en høyere opp i hiriarkiet, da toggles det. 

## 🧪 Testing

