### PR TITLE
171 toggle open/close function

### DIFF
--- a/src/components/function-card.tsx
+++ b/src/components/function-card.tsx
@@ -47,7 +47,9 @@ export function FunctionCard({
 									!func?.data?.path.includes(path) &&
 									!path.includes(`${func?.data?.path}`),
 							),
-							`${func?.data?.path}`,
+							...(search.path.includes(`${func?.data?.path}`)
+								? [func?.data?.path.slice(0, func?.data?.path.lastIndexOf("."))]
+								: [`${func?.data?.path}`]),
 						],
 
 						edit: search.edit,


### PR DESCRIPTION
## Beskrivelse

🥅 Mål med PRen: Ønkser å kunne "unseelecte"/"lukke" en funsjon som allerede er valgt ved å klikke på den.  

## Løsning

🆕 Endring: Endret navigation i card sin onclick: De eksiterende pathsene blir fjernet fra path listen og lagt til igjen, med mindre man klikker på en høyere opp i hiriarkiet, da toggles det. 

## 🧪 Testing


