### PR TITLE
194 bug fikse avstand/alignment til parent - child card

### DIFF
--- a/src/components/function-column.tsx
+++ b/src/components/function-column.tsx
@@ -14,7 +14,6 @@ import { useHasFunctionAccess } from "@/hooks/use-has-function-access";
 type FunctionFolderProps = {
 	functionIds: number[];
 };
-const FUNCTION_VIEW_OFFSET = 312;
 
 export function FunctionColumn({ functionIds }: FunctionFolderProps) {
 	const [functionPositions, setFunctionPositions] = useState<number[]>([]);
@@ -48,12 +47,12 @@ export function FunctionColumn({ functionIds }: FunctionFolderProps) {
 	useLayoutEffect(() => {
 		const getParentPosition = (parentId: number) => {
 			const parent = document.getElementById(parentId.toString());
+			const top = document.getElementById("topBox");
 
-			if (!parent) return 0;
+			if (!parent || !top) return 0;
 
-			const scrollTop = window.scrollY || document.documentElement.scrollTop;
 			return (
-				parent.getBoundingClientRect().top - FUNCTION_VIEW_OFFSET + scrollTop
+				parent.getBoundingClientRect().top - top.getBoundingClientRect().bottom
 			);
 		};
 
@@ -72,6 +71,7 @@ export function FunctionColumn({ functionIds }: FunctionFolderProps) {
 				textAlign="center"
 				borderColor="gray.400"
 				minH="46px"
+				id="topBox"
 			>
 				<Text size="lg" fontWeight="700">
 					{config.columnName} nivå {currentLevel + 1}


### PR DESCRIPTION
## Beskrivelse

🥅 Mål med PRen:  fikse at avstanden som var off
![image](https://github.com/user-attachments/assets/20c1c6a2-2c07-4619-87e4-7426a0b15e69)


## Løsning

🆕 Endring: Ved å erstatte ofsettet til toppen som en konstant, tar jeg heller å trekker fra avstanden fra bunnen av header-boksen i function-colonen. 


