### PR TITLE
separate expanded and selected card

### DIFF
--- a/src/components/function-card-expandable-content.tsx
+++ b/src/components/function-card-expandable-content.tsx
@@ -1,12 +1,11 @@
-import { Flex, Text, Skeleton, Stack } from "@kvib/react";
 import { useFunction } from "@/hooks/use-function";
-import { EditAndSelectButtons } from "./edit-and-select-buttons";
 import { MetadataView } from "./metadata/metadata-view";
 import { useMetadata } from "@/hooks/use-metadata";
 import { Route } from "@/routes";
 import { OboFlowFeature } from "../../frisk.config";
+import { Stack } from "@kvib/react";
 
-export function FunctionCardSelectedView({
+export function FunctionCardExpandableContent({
 	functionId,
 }: { functionId: number }) {
 	const { func } = useFunction(functionId);
@@ -15,21 +14,7 @@ export function FunctionCardSelectedView({
 	const { flags } = Route.useSearch();
 
 	return (
-		<Stack paddingLeft="10px" w="100%">
-			<Flex alignItems="center" w="100%" flex-wrap="wrap">
-				<Skeleton isLoaded={!func.isLoading} flex={1} minWidth={0}>
-					<Text
-						fontWeight="bold"
-						as="span"
-						display="flex"
-						w="100%"
-						overflow="hidden"
-					>
-						{func.data?.name ?? "<Det skjedde en feil>"}
-					</Text>
-				</Skeleton>
-				<EditAndSelectButtons functionId={functionId} selected />
-			</Flex>
+		<Stack pl="10px">
 			{config.metadata?.map((meta) => (
 				<MetadataView key={meta.key} metadata={meta} functionId={functionId} />
 			))}

--- a/src/components/function-card.tsx
+++ b/src/components/function-card.tsx
@@ -1,8 +1,8 @@
 import { useFunction } from "@/hooks/use-function";
 import { Route } from "@/routes";
-import { Card, Flex, IconButton, Skeleton, Text } from "@kvib/react";
+import { Card, Flex, IconButton, Skeleton, Stack, Text } from "@kvib/react";
 import { FunctionCardEdit } from "./function-card-edit";
-import { FunctionCardSelectedView } from "./function-card-selected-view";
+import { FunctionCardExpandableContent } from "./function-card-expandable-content";
 import { EditAndSelectButtons } from "./edit-and-select-buttons";
 import { useEffect, useState } from "react";
 import { useHasFunctionAccess } from "@/hooks/use-has-function-access";
@@ -16,6 +16,12 @@ export function FunctionCard({
 	const { func } = useFunction(functionId);
 	const search = Route.useSearch();
 	const navigate = Route.useNavigate();
+
+	const [isCardExpanded, setIsCardExpanded] = useState(false);
+
+	const toggleCardExpanded = () => {
+		setIsCardExpanded((prev) => !prev);
+	};
 
 	const [bottomMargin, setBottomMargin] = useState(0);
 
@@ -77,32 +83,47 @@ export function FunctionCard({
 			>
 				{search.edit === functionId && hasAccess ? (
 					<FunctionCardEdit functionId={functionId} />
-				) : selected ? (
-					<FunctionCardSelectedView functionId={functionId} />
 				) : (
-					<>
-						<IconButton
-							type="button"
-							colorScheme="gray"
-							variant="ghost"
-							aria-label="drag"
-							icon="drag_indicator"
-							isDisabled={!hasAccess}
-						/>
-
-						<Skeleton isLoaded={!func.isLoading} flex="1" minWidth={0}>
-							<Text
-								fontWeight="bold"
-								as="span"
-								display="flex"
-								w="100%"
-								overflow="hidden"
-							>
-								{func.data?.name ?? "<Det skjedde en feil>"}
-							</Text>
-						</Skeleton>
-						<EditAndSelectButtons functionId={functionId} selected={false} />
-					</>
+					<Stack w="100%">
+						<Flex alignItems="center" w="100%" flex-wrap="wrap">
+							<IconButton
+								type="button"
+								colorScheme="gray"
+								variant="ghost"
+								aria-label="drag"
+								icon="drag_indicator"
+								isDisabled={!hasAccess}
+							/>
+							<IconButton
+								colorScheme="gray"
+								variant="tertiary"
+								aria-label={isCardExpanded ? "close card" : "expand card"}
+								icon={isCardExpanded ? "keyboard_arrow_down" : "chevron_right"}
+								onClick={(e) => {
+									e.stopPropagation();
+									toggleCardExpanded();
+								}}
+							/>
+							<Skeleton isLoaded={!func.isLoading} flex="1" minWidth={0}>
+								<Text
+									fontWeight="bold"
+									as="span"
+									display="flex"
+									w="100%"
+									overflow="hidden"
+								>
+									{func.data?.name ?? "<Det skjedde en feil>"}
+								</Text>
+							</Skeleton>
+							<EditAndSelectButtons
+								functionId={functionId}
+								selected={selected}
+							/>
+						</Flex>
+						{isCardExpanded && (
+							<FunctionCardExpandableContent functionId={functionId} />
+						)}
+					</Stack>
 				)}
 			</Flex>
 		</Card>


### PR DESCRIPTION
## Beskrivelse
Når man selecter mange kort tar det veldig mye plass

## Løsning
Skiller på å selecte et kort og expande det.
- La til en knapp der man kan utvide kortet for å se mer info
- Hvis man bare selecter kortet så blir det blått uten å vise hele informasjonen

![Screenshot 2025-01-14 at 14 51 26](https://github.com/user-attachments/assets/6bf969de-2a7d-432a-9680-11dc3fe0b3d7)
![Screenshot 2025-01-14 at 14 51 41](https://github.com/user-attachments/assets/411f4a9e-ffd3-40eb-8732-d365132e9eee)

