### PR TITLE
correct regelrett api scopes for SKIP

### DIFF
--- a/frisk.config.tsx
+++ b/frisk.config.tsx
@@ -5,7 +5,7 @@ import {
 	getMyMicrosoftTeams,
 	getTeam,
 } from "@/services/backend";
-import { getregelrettFrontendUrl } from "@/config";
+import { getRegelrettClientId, getregelrettFrontendUrl } from "@/config";
 import { object, string, array, type z } from "zod";
 import { Button, FormControl, FormLabel, Select } from "@kvib/react";
 import type { useFunction } from "@/hooks/use-function";
@@ -388,9 +388,10 @@ const RegelrettSchema = object({
 type RegelrettSchema = z.infer<typeof RegelrettSchema>;
 
 async function getRegelrettTokens() {
+	const REGELRETT_CLIENT_ID = getRegelrettClientId();
 	const regelrettScope =
 		import.meta.env.MODE === "skip"
-			? "api://regelrett-backend/regelrett"
+			? `api://${REGELRETT_CLIENT_ID}/regelrett`
 			: "api://e9dc946b-6fef-44ab-82f1-c0ec2e402903/.default";
 
 	const accounts = msalInstance.getAllAccounts();

--- a/nginx/main.js
+++ b/nginx/main.js
@@ -5,7 +5,7 @@ function getConfig(r) {
 		redirect_uri: process.env.VITE_LOGIN_REDIRECT_URI,
 		backend_url: process.env.VITE_BACKEND_URL,
 		regelrett_frontend_url: process.env.VITE_REGELRETT_FRONTEND_URL,
-		regelrett_client_id: process.env.VITE_REGELRETT_CLIENT_ID,
+		regelrett_client_id: process.env.REGELRETT_CLIENT_ID,
 	};
 	r.headersOut["Content-Type"] = "application/json";
 	r.return(200, JSON.stringify(config));

--- a/nginx/main.js
+++ b/nginx/main.js
@@ -1,13 +1,14 @@
 function getConfig(r) {
-    var config = {    
-        clientId: process.env.VITE_CLIENT_ID,
-        authority: process.env.VITE_AUTHORITY,
-        redirect_uri: process.env.VITE_LOGIN_REDIRECT_URI,
-        backend_url: process.env.VITE_BACKEND_URL,
-        regelrett_frontend_url: process.env.VITE_REGELRETT_FRONTEND_URL
-    };
-    r.headersOut['Content-Type'] = 'application/json';
-    r.return(200, JSON.stringify(config));
+	var config = {
+		clientId: process.env.VITE_CLIENT_ID,
+		authority: process.env.VITE_AUTHORITY,
+		redirect_uri: process.env.VITE_LOGIN_REDIRECT_URI,
+		backend_url: process.env.VITE_BACKEND_URL,
+		regelrett_frontend_url: process.env.VITE_REGELRETT_FRONTEND_URL,
+		regelrett_client_id: process.env.VITE_REGELRETT_CLIENT_ID,
+	};
+	r.headersOut["Content-Type"] = "application/json";
+	r.return(200, JSON.stringify(config));
 }
 
 export default { getConfig };

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,9 +22,7 @@ const defaultConfig: IConfig = {
 	regelrett_frontend_url:
 		import.meta.env.VITE_REGLERRETT_FRONTEND_URL ??
 		"https://regelrett-frontend-1024826672490.europe-north1.run.app",
-	regelrett_client_id:
-		import.meta.env.VITE_REGELRETT_CLIENT_ID ??
-		"api://e9dc946b-6fef-44ab-82f1-c0ec2e402903/.default",
+	regelrett_client_id: import.meta.env.REGELRETT_CLIENT_ID ?? "",
 };
 
 export async function getConfig(): Promise<IConfig> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ export interface IConfig {
 	redirect_uri: string;
 	backend_url: string;
 	regelrett_frontend_url: string;
+	regelrett_client_id: string;
 }
 
 const defaultConfig: IConfig = {
@@ -21,6 +22,9 @@ const defaultConfig: IConfig = {
 	regelrett_frontend_url:
 		import.meta.env.VITE_REGLERRETT_FRONTEND_URL ??
 		"https://regelrett-frontend-1024826672490.europe-north1.run.app",
+	regelrett_client_id:
+		import.meta.env.VITE_REGELRETT_CLIENT_ID ??
+		"api://e9dc946b-6fef-44ab-82f1-c0ec2e402903/.default",
 };
 
 export async function getConfig(): Promise<IConfig> {
@@ -61,4 +65,8 @@ export function getBackendUrl() {
 
 export function getregelrettFrontendUrl() {
 	return config.regelrett_frontend_url;
+}
+
+export function getRegelrettClientId() {
+	return config.regelrett_client_id;
 }


### PR DESCRIPTION
## Beskrivelse
Det måtte være forskjellige API scopes for dev og prod på SKIP. Så det blir brukt regelrett clientId for for å skille dem.

#251 
