### PR TITLE
søkbar team dropdown

### DIFF
--- a/src/components/function-column.tsx
+++ b/src/components/function-column.tsx
@@ -209,6 +209,10 @@ function ChildrenGroupItem({
 				m.key === filter.key &&
 				(filter.value === undefined ||
 					m.value === filter.value ||
+					(filter.value &&
+						typeof filter.value === "object" &&
+						"value" in filter.value &&
+						filter.value.value === m.value) ||
 					(Array.isArray(filter.value) &&
 						filter.value.every((v) =>
 							metadata.data?.some(

--- a/src/components/metadata/metadata-input.tsx
+++ b/src/components/metadata/metadata-input.tsx
@@ -290,7 +290,6 @@ function SingleSelect({
 				debounceTime={100}
 				defaultOptions
 				onChange={(newValue) => {
-					console.log(newValue);
 					// @ts-expect-error
 					setCurrentMetadataValue(newValue);
 					// @ts-expect-error

--- a/src/components/metadata/metadata-input.tsx
+++ b/src/components/metadata/metadata-input.tsx
@@ -127,7 +127,7 @@ function SelectInput({
 			metadataToDisplay?.map((m) => ({
 				queryKey: [functionId, metadata.key, m.value, "getDisplayValue"],
 				queryFn: async () => {
-					return metadata.getDisplayValue?.(m);
+					return metadata.getDisplayValue?.(m) ?? null;
 				},
 			})) ?? [],
 	});
@@ -150,7 +150,7 @@ function SelectInput({
 	>();
 
 	const [newMetadataValue, setCurrentMetadataValue] = useState<
-		MultiSelectOption | undefined
+		MultiSelectOption | undefined | null
 	>();
 
 	const { metadata: parentMetadata } = useMetadata(parentFunctionId);
@@ -228,7 +228,11 @@ function SelectInput({
 						<SingleSelect
 							options={options}
 							metadata={metadata}
-							currentMetadataValue={newMetadataValue ?? currentMetadataValue}
+							currentMetadataValue={
+								(newMetadataValue !== undefined
+									? newMetadataValue
+									: currentMetadataValue) ?? undefined
+							}
 							parentMetadataValue={parentMetadataValue}
 							setCurrentMetadataValue={setCurrentMetadataValue}
 							onChange={onChange}
@@ -286,6 +290,7 @@ function SingleSelect({
 				debounceTime={100}
 				defaultOptions
 				onChange={(newValue) => {
+					console.log(newValue);
 					// @ts-expect-error
 					setCurrentMetadataValue(newValue);
 					// @ts-expect-error
@@ -304,7 +309,7 @@ function SingleSelect({
 					callback(filteredOptions);
 				}}
 			/>
-			<Input type="hidden" name={metadata.key} value={value?.value} />
+			<Input type="hidden" name={metadata.key} value={value?.value ?? ""} />
 		</>
 	);
 }


### PR DESCRIPTION
## Beskrivelse
Gjøre team dropdown søkbar slik at det er enklere å finne riktig team.

## Løsning
Endringen i bunn og grunn er å bytte Select-komponenten med SearchAsync i vår egen SingleSelect-komponent som ligger i metadata-input, det fordi at SearchAsync kommer med søkefunksjonalitet. 
Det krevde videre litt flere endringer for å få det til å funke. SearchAsync krever at elementene er på formatet {label: string, value: string}, mye av endringene er gjort for å få det på det formatet. Vi hadde fra før av en egen MultiSelect-komponent i metadata-input, så gjør akkurat det samme nå med SingleSelect, bare at SingleSelect ikke har en liste av options. Altså ikke liste av typen MultiSelectOption som i MultiSelect, men en enkel MultiSelectOption. Usikker på om denne forklaringen gir så mye mening, men kan evt. forklare i morgen:)

