### PR TITLE
Endre teamet på skjema i RR når man bytter team på funksjon

### DIFF
--- a/src/components/function-card-edit.tsx
+++ b/src/components/function-card-edit.tsx
@@ -110,6 +110,8 @@ export function FunctionCardEdit({ functionId }: { functionId: number }) {
 							(await updateMetadataValue.mutateAsync({
 								id: existingMd.id,
 								value: formElement.value,
+								key: existingMd.key,
+								functionId: existingMd.functionId,
 							}));
 					}
 				}

--- a/src/hooks/use-metadata.ts
+++ b/src/hooks/use-metadata.ts
@@ -6,9 +6,12 @@ import {
 	patchMetadataValue,
 } from "@/services/backend";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getConfig } from "../../frisk.config";
+import { useToast } from "@kvib/react";
 
 export function useMetadata(functionId: number | undefined) {
 	const queryClient = useQueryClient();
+	const toast = useToast();
 	const metadata = useQuery({
 		queryKey: ["functions", functionId, "metadata"],
 		queryFn: async () => {
@@ -112,7 +115,34 @@ export function useMetadata(functionId: number | undefined) {
 	});
 
 	const updateMetadataValue = useMutation({
-		mutationFn: patchMetadataValue,
+		mutationFn: async (
+			input: Parameters<typeof patchMetadataValue>[0] & {
+				key: string;
+				functionId: number;
+			},
+		) => {
+			const { key, functionId, ...validMetadata } = input;
+			await patchMetadataValue(validMetadata);
+			try {
+				(await getConfig()).metadata
+					?.find((m) => m.key === input.key)
+					?.onChange?.(input);
+			} catch (error) {
+				console.error("Error updating metadata value:", error);
+				const toastId = "update-metadata-value";
+				if (!toast.isActive(toastId)) {
+					toast({
+						id: toastId,
+						title: "Å nei!",
+						description:
+							"Noe gikk galt under endringen av metadata. Prøv gjerne igjen!",
+						status: "error",
+						duration: 5000,
+						isClosable: true,
+					});
+				}
+			}
+		},
 		onMutate: async (updatedMetadata) => {
 			await queryClient.cancelQueries({
 				queryKey: ["functions", functionId, "metadata"],


### PR DESCRIPTION
## Beskrivelse
Når man endrer team på en funksjon vil man at teamet som skjemautfyllingene på funksjonen tilhører også endres til samme team.

## Løsning
La til en optional onChange funksjon i configen. I updateMetadataValue i useMetadata sjekkes det om onChange er satt og da kjører funksjonen fra configen. 
