### PR TITLE
Added permalink and copy link button

### DIFF
--- a/src/components/function-card-edit.tsx
+++ b/src/components/function-card-edit.tsx
@@ -200,6 +200,18 @@ export function FunctionCardEdit({ functionId }: { functionId: number }) {
 								isLoading={isMutating > 0}
 							/>
 						</Tooltip>
+						<Tooltip label="Kopier lenke" placement="top">
+							<IconButton
+								aria-label="Copy link"
+								variant="tertiary"
+								icon="content_copy"
+								colorScheme="blue"
+								onClick={() => {
+									const permalink = `${window.location.origin}?path=%5B%22${functionId}%22%5D`;
+									navigator.clipboard.writeText(permalink);
+								}}
+							/>
+						</Tooltip>
 					</Flex>
 				</Stack>
 			</form>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -67,6 +67,20 @@ function Index() {
 						edit: undefined,
 					},
 				});
+			} else if (func.isSuccess) {
+				if (
+					search.path.length === 1 &&
+					search.path[0].split(".").length === 1 &&
+					search.path[0] !== "1"
+				) {
+					navigate({
+						search: {
+							...search,
+							path: [functions[0].data?.path],
+							edit: undefined,
+						},
+					});
+				}
 			}
 		});
 	}, [functions, navigate, idArrays, search]);


### PR DESCRIPTION
## Beskrivelse

🥅 Mål med PRen: ønske om å ha en lenke som alltid fører deg til funksjonen uavhengig om pathen dens skulle endres. 

## Løsning

🆕 Endring: i `index.tsx` har jeg lagt til en sjekk på om det kun er en id i pathen og den ikke er rot (1), så finner man pathen til den funksjonsiden og navigerer dit.

I tilleg har jeg lagt til en copy link icon button i redigeringsmodus. Denne bør flyttes til et bedre sted -se egen ticket for det. 


![image](https://github.com/user-attachments/assets/e57fe466-1894-440e-9b10-daa18544d034)

