### PR TITLE
delete metadata if schema does not exist in RR

### DIFF
--- a/frisk.config.tsx
+++ b/frisk.config.tsx
@@ -181,7 +181,7 @@ export async function getConfig(): Promise<FriskConfig> {
 							await fetchFromRegelrett(`contexts/${contextId}`);
 						} catch (error) {
 							await deleteFunctionMetadata(input.id);
-							return { displayValue: null as unknown as string };
+							return { displayValue: undefined };
 						}
 
 						return {
@@ -273,7 +273,7 @@ type GeneralMetadataContent = {
 		functionId: number;
 		id: number;
 	}) => Promise<{
-		displayValue: string;
+		displayValue?: string;
 		value?: string;
 		displayOptions?:
 			| {

--- a/frisk.config.tsx
+++ b/frisk.config.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import {
+	deleteFunctionMetadata,
 	getFunction,
 	getFunctionMetadata,
 	getFunctions,
@@ -175,6 +176,14 @@ export async function getConfig(): Promise<FriskConfig> {
 							redirectBackTitle: "Funksjonsregisteret",
 						});
 						const url = `${getregelrettFrontendUrl()}/context/${contextId}?${searchParams.toString()}`;
+						//Check if the context exists in regelrett and delete metadata if it does not exist
+						try {
+							await fetchFromRegelrett(`contexts/${contextId}`);
+						} catch (error) {
+							await deleteFunctionMetadata(input.id);
+							return { displayValue: null as unknown as string };
+						}
+
 						return {
 							displayValue: schema.name,
 							displayOptions: {


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen:
Vi vil ikke vise skjemaer som ikke finnes på funksjoner. Hvis et skjema blir slettet i RR forblir det en link som bare leder til en 404 i RR. 

**Løsning**

🆕 Endring: 
La til en sjekk i getDisplayValue som sjekker om contexten eksisterer i RR før url'en sendes videre til SchemaDisplay-komponenten. Hvis den ikke eksisterer så slettes også skjema-metadataen fra funksjonen slik at et nytt skjema kan bli opprettet. 

**🧪 Testing**
Synes denne `return { displayValue: null as unknown as string };` ble litt rar. Usikker på om det er bedre å tillatte null på getDisplayValue funksjonen i stedet hmm

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
