### PR TITLE
add header to schemas once

### DIFF
--- a/frisk.config.tsx
+++ b/frisk.config.tsx
@@ -151,6 +151,7 @@ export async function getConfig(): Promise<FriskConfig> {
 			...schemas.map(
 				(schema): InputMetadata => ({
 					key: schema.id,
+					title: "Sikkerhetsskjema",
 					type: "text",
 					textArea: false,
 					displayName: schema.name,

--- a/src/components/function-card-selected-view.tsx
+++ b/src/components/function-card-selected-view.tsx
@@ -11,6 +11,7 @@ export function FunctionCardSelectedView({
 	const { func } = useFunction(functionId);
 	const { metadata, addMetadata } = useMetadata(functionId);
 	const { config } = Route.useLoaderData();
+	const displayedTitles = new Set<string>();
 
 	return (
 		<Stack pl="10px" w="100%" overflow="hidden">
@@ -28,9 +29,19 @@ export function FunctionCardSelectedView({
 				</Skeleton>
 				<EditAndSelectButtons functionId={functionId} selected />
 			</Flex>
-			{config.metadata?.map((meta) => (
-				<MetadataView key={meta.key} metadata={meta} functionId={functionId} />
-			))}
+			{config.metadata?.map((meta) => {
+				const hasMetadata = metadata.data?.some((m) => m.key === meta.key);
+				const showTitle = meta.title ? !displayedTitles.has(meta.title) : false;
+				if (meta.title && hasMetadata) displayedTitles.add(meta.title);
+				return (
+					<MetadataView
+						key={meta.key}
+						metadata={meta}
+						functionId={functionId}
+						showTitle={showTitle}
+					/>
+				);
+			})}
 			{config.functionCardComponents.map((Component) => (
 				<Component
 					key={Component.toString()}

--- a/src/components/metadata/metadata-view.tsx
+++ b/src/components/metadata/metadata-view.tsx
@@ -9,9 +9,11 @@ import { useIndicators } from "@/hooks/use-indicators";
 export function MetadataView({
 	metadata,
 	functionId,
+	showTitle,
 }: {
 	metadata: Metadata;
 	functionId: number;
+	showTitle: boolean;
 }) {
 	const search = Route.useSearch();
 	const indicator = search.indicators?.metadata.find(
@@ -40,7 +42,7 @@ export function MetadataView({
 
 	return (
 		<Flex key={metadata.key} flexDirection="column">
-			{metadata.title && (
+			{showTitle && metadata.title && (
 				<Text fontSize="sm" fontWeight="700">
 					{metadata.title}:
 				</Text>


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: *Hvorfor er oppgaven laget og hvilke problem løser denne PRen?*
Legge til tittel for skjema på funksjonskort. Selv om det er en liste med skjemaer i configen, har vi lyst til å kun vise tittel en gang på det øverste skjemaet.

**Løsning**

🆕 Endring: *Skriv kort hva endringen i denne PRen er og hvorfor den har løst problemet.*
- La til "title" i configen
- la til showtitle prop i metadataView
- I selectedView lager jeg et sett over titler som har blitt lagt til på funksjonskortet og sender med showtitle false til MetadataView hvis tittelen allerede eksisterer på kortet.

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*
Kan evt. sjekke at det faktisk funker som forventet. F.eks. at hvis man legger til begge skjemaer og sletter det øverste så flytter tittelen seg til det nederste skjemaet.

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
