### PR TITLE
remove edit from url on delete

### DIFF
--- a/src/components/delete-function-modal.tsx
+++ b/src/components/delete-function-modal.tsx
@@ -62,6 +62,7 @@ export function DeleteFunctionModal({ onClose, isOpen, functionId }: Props) {
 												? deletedFunctionParentPath
 												: pathString,
 										) ?? ["1"],
+										edit: undefined,
 									},
 								});
 							}}


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Når man sletter en funksjon så er man i "edit mode" og da legges til edit-parameter i url'en. Etter at funksjonen er slettet blir ikke edit-parameteren fjernet som gjør at man ikke kan f.eks. åpne en annen funksjon eller navigere seg rundt.

**Løsning**

🆕 Endring:
La til at edit blir undefined når man sletter en funksjon

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
