### PR TITLE
move copy url button to selected view

### DIFF
--- a/frisk.config.tsx
+++ b/frisk.config.tsx
@@ -410,7 +410,7 @@ function createSchemaComponent(schemas: RegelrettSchema[]) {
 					colorScheme="blue"
 					size="sm"
 					width="fit-content"
-					my="16px"
+					mt="16px"
 					onClick={(e) => e.stopPropagation()}
 					isDisabled={!selectedSchema}
 				>

--- a/src/components/function-card-edit.tsx
+++ b/src/components/function-card-edit.tsx
@@ -202,18 +202,6 @@ export function FunctionCardEdit({ functionId }: { functionId: number }) {
 								isLoading={isMutating > 0}
 							/>
 						</Tooltip>
-						<Tooltip label="Kopier lenke" placement="top">
-							<IconButton
-								aria-label="Copy link"
-								variant="tertiary"
-								icon="content_copy"
-								colorScheme="blue"
-								onClick={() => {
-									const permalink = `${window.location.origin}?path=%5B%22${functionId}%22%5D`;
-									navigator.clipboard.writeText(permalink);
-								}}
-							/>
-						</Tooltip>
 					</Flex>
 				</Stack>
 			</form>

--- a/src/components/function-card-selected-view.tsx
+++ b/src/components/function-card-selected-view.tsx
@@ -2,7 +2,7 @@ import { useFunction } from "@/hooks/use-function";
 import { MetadataView } from "./metadata/metadata-view";
 import { useMetadata } from "@/hooks/use-metadata";
 import { Route } from "@/routes";
-import { Flex, Skeleton, Stack, Text } from "@kvib/react";
+import { Button, Flex, Skeleton, Stack, Text } from "@kvib/react";
 import { EditAndSelectButtons } from "./edit-and-select-buttons";
 
 export function FunctionCardSelectedView({
@@ -50,6 +50,22 @@ export function FunctionCardSelectedView({
 					addMetadata={addMetadata}
 				/>
 			))}
+			<Button
+				aria-label="Copy link"
+				padding="0"
+				justifyContent="left"
+				variant="tertiary"
+				leftIcon="content_copy"
+				colorScheme="blue"
+				fontSize="sm"
+				onClick={(e) => {
+					e.stopPropagation();
+					const permalink = `${window.location.origin}?path=%5B%22${func.data?.id}%22%5D`;
+					navigator.clipboard.writeText(permalink);
+				}}
+			>
+				Kopier lenke til funksjonskort
+			</Button>
 		</Stack>
 	);
 }


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Flytte "kopier lenke"-knappen til selected view fra redigeringsviewet for å gjøre den mer tilgjengelig

**Løsning**

🆕 Endring: 
Flyttet knappen og la til tekst

Før i redigeringsmodus:
<img width="382" alt="image" src="https://github.com/user-attachments/assets/f504be7d-96df-4ce8-972e-f73367b127c7" />


Nå i selected view:
<img width="370" alt="image" src="https://github.com/user-attachments/assets/72de4070-a937-4df7-80e9-3db382803bd4" />

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
