### PR TITLE
317 redusere ant funksjoner hentet ved søk

### DIFF
--- a/DockerfileForSkip
+++ b/DockerfileForSkip
@@ -11,7 +11,7 @@ RUN bun run build:skip
 
 FROM nginx:stable-alpine
 # Update to exact version to keep image "mostly" stable
-RUN apk upgrade libxml2=2.12.7-r2
+RUN apk upgrade libxml2-2.13.4-r5
 RUN apk add --no-cache nginx-mod-http-js
 
 COPY ./nginx/nginx.conf /etc/nginx/nginx.conf

--- a/DockerfileForSkip
+++ b/DockerfileForSkip
@@ -10,6 +10,8 @@ RUN bun install --frozen-lockfile
 RUN bun run build:skip
 
 FROM nginx:stable-alpine
+# Update to exact version to keep image "mostly" stable
+RUN apk upgrade libxml2=2.12.7-r2
 RUN apk add --no-cache nginx-mod-http-js
 
 COPY ./nginx/nginx.conf /etc/nginx/nginx.conf

--- a/frisk.config.tsx
+++ b/frisk.config.tsx
@@ -410,7 +410,7 @@ function createSchemaComponent(schemas: RegelrettSchema[]) {
 					colorScheme="blue"
 					size="sm"
 					width="fit-content"
-					my="16px"
+					mt="16px"
 					onClick={(e) => e.stopPropagation()}
 					isDisabled={!selectedSchema}
 				>

--- a/src/components/function-card-edit.tsx
+++ b/src/components/function-card-edit.tsx
@@ -202,18 +202,6 @@ export function FunctionCardEdit({ functionId }: { functionId: number }) {
 								isLoading={isMutating > 0}
 							/>
 						</Tooltip>
-						<Tooltip label="Kopier lenke" placement="top">
-							<IconButton
-								aria-label="Copy link"
-								variant="tertiary"
-								icon="content_copy"
-								colorScheme="blue"
-								onClick={() => {
-									const permalink = `${window.location.origin}?path=%5B%22${functionId}%22%5D`;
-									navigator.clipboard.writeText(permalink);
-								}}
-							/>
-						</Tooltip>
 					</Flex>
 				</Stack>
 			</form>

--- a/src/components/function-card-selected-view.tsx
+++ b/src/components/function-card-selected-view.tsx
@@ -2,7 +2,7 @@ import { useFunction } from "@/hooks/use-function";
 import { MetadataView } from "./metadata/metadata-view";
 import { useMetadata } from "@/hooks/use-metadata";
 import { Route } from "@/routes";
-import { Flex, Skeleton, Stack, Text } from "@kvib/react";
+import { Button, Flex, Skeleton, Stack, Text } from "@kvib/react";
 import { EditAndSelectButtons } from "./edit-and-select-buttons";
 
 export function FunctionCardSelectedView({
@@ -50,6 +50,22 @@ export function FunctionCardSelectedView({
 					addMetadata={addMetadata}
 				/>
 			))}
+			<Button
+				aria-label="Copy link"
+				padding="0"
+				justifyContent="left"
+				variant="tertiary"
+				leftIcon="content_copy"
+				colorScheme="blue"
+				fontSize="sm"
+				onClick={(e) => {
+					e.stopPropagation();
+					const permalink = `${window.location.origin}?path=%5B%22${func.data?.id}%22%5D`;
+					navigator.clipboard.writeText(permalink);
+				}}
+			>
+				Kopier lenke til funksjonskort
+			</Button>
 		</Stack>
 	);
 }

--- a/src/components/search-field.tsx
+++ b/src/components/search-field.tsx
@@ -15,7 +15,6 @@ export function SearchField() {
 				<SearchAsync
 					size="sm"
 					debounceTime={300}
-					defaultOptions
 					loadOptions={async (inputValue, callback) => {
 						const functions = await getFunctions(inputValue.trim());
 


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Ved innlasting av siden hentet søkefunksjonen alle funksjonene fra backenden, noe som er unødvendig da man ikke har klikket seg inn på søkefeltet. 

**Løsning**

🆕 Endring: 

Fjernet defaultOptions på søke-komponenten, slik at den kun henter funksjoner når det skrives noe i søke-feltet.
