### PR TITLE
314 fikse tekst-input på meta-datafilter

### DIFF
--- a/src/components/function-column-view.tsx
+++ b/src/components/function-column-view.tsx
@@ -33,8 +33,8 @@ import {
 	type MultiSelectOption,
 } from "./metadata/metadata-input";
 import { SearchField } from "./search-field";
-import { useState } from "react";
 import { FunctionCard } from "./function-card";
+import { useState } from "react";
 
 type FunctionColumnViewProps = {
 	path: string[];
@@ -342,35 +342,39 @@ function Filters(props: {
 									);
 								})}
 						</Select>
-						<MetadataInput
-							hideLabel
-							value={filterMeta.value as string | MultiSelectOption[]}
-							onChange={(value) => {
-								navigate({
-									search: {
-										...search,
-										...(search[props.type]
-											? {
-													[props.type]: {
-														metadata: search[props.type]?.metadata.map((m) => {
-															if (m.key === filterMeta.key) {
-																return {
-																	key: filterMeta.key,
-																	value: value !== "" ? value : undefined,
-																};
-															}
-															return m;
-														}),
-													},
-												}
-											: {}),
-									},
-								});
-							}}
-							metadata={metadata}
-							functionId={undefined}
-							parentFunctionId={undefined}
-						/>
+						{metadata.type === "select" && (
+							<MetadataInput
+								hideLabel
+								value={filterMeta.value as string | MultiSelectOption[]}
+								onChange={(value) => {
+									navigate({
+										search: {
+											...search,
+											...(search[props.type]
+												? {
+														[props.type]: {
+															metadata: search[props.type]?.metadata.map(
+																(m) => {
+																	if (m.key === filterMeta.key) {
+																		return {
+																			key: filterMeta.key,
+																			value: value !== "" ? value : undefined,
+																		};
+																	}
+																	return m;
+																},
+															),
+														},
+													}
+												: {}),
+										},
+									});
+								}}
+								metadata={metadata}
+								functionId={undefined}
+								parentFunctionId={undefined}
+							/>
+						)}
 						<IconButton
 							aria-label="Remove filter"
 							onClick={() => {


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: Man kunne kun skrive en bokstav før inputfeltet "søkte" og du mista fokus og filteret ble aktivert på den ene bokstaven.

**Løsning**

🆕 Endring: 
Problemet oppstår da man henter det samme inputfeltet for tekst som man ser i redigeringsmodus på funksjonskortet - men disse inputfeltene er ikke egnet for søk.  I tillegg kommer ikke funksjonen fra et brukerbehov, men heller fordi det krevde mer kode å slette funksjonaliteten enn å beholde den. Valgte derfor sammen med designer å slette funksjonaliteten inntill videre. 

Altså - du kan fortsatt filterer på alle funksjonene som har en besrkivelse, men du kan ikke søke på beskrivelses-tekst. Samme gjelder URL.


| før | etter |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/050c8e04-2b5b-4200-9131-540703026232) | ![image](https://github.com/user-attachments/assets/0e7ecb6b-0cc8-4bd2-b0cd-dc1fa52850a9)|

