### PR TITLE
added scrollbar when hovering and scrolling description on functioncard

### DIFF
--- a/src/components/metadata/metadata-value.tsx
+++ b/src/components/metadata/metadata-value.tsx
@@ -164,12 +164,20 @@ const TextView: React.FC<TextViewProps> = ({
 					fontSize="sm"
 					value={displayValue ?? ""}
 					borderRadius="5px"
-					_hover={{ cursor: "inherit" }}
+					_hover={{ cursor: "inherit", overflowY: "auto" }}
 					maxHeight={"70px"}
+					minHeight={"auto"}
+					overflowY={"hidden"}
 					sx={{
-						minHeight: "auto",
 						"&::-webkit-scrollbar": {
-							display: "none",
+							width: "6px",
+						},
+						"&::-webkit-scrollbar-thumb": {
+							backgroundColor: "gray.400",
+							borderRadius: "3px",
+						},
+						"&::-webkit-scrollbar-track": {
+							background: "transparent",
 						},
 					}}
 				/>


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Gjøre det enklere å se at du kan skrolle i beskrivelsen hvis teksten overflower. 

**Løsning**

🆕 Endring: 
Ved hover eller når man scroller så vises scrollbaren.


|før | etter|
| --- | --- |
| ![image](https://github.com/user-attachments/assets/f437c5a5-7106-4b5c-a5b5-f8b1fd677dc3) | ![image](https://github.com/user-attachments/assets/0cd34f78-a3fa-4ffa-a1dc-0c9a41e4544f)|
