### PR TITLE
håndtere visning av sikkerhetsskjema ved manglende tilgang

### DIFF
--- a/frisk.config.tsx
+++ b/frisk.config.tsx
@@ -14,16 +14,19 @@ import {
 	Flex,
 	FormControl,
 	FormLabel,
+	Icon,
 	IconButton,
 	Link,
 	Select,
 	useDisclosure,
+	Text,
 } from "@kvib/react";
 import type { useFunction } from "@/hooks/use-function";
 import { msalInstance } from "@/services/msal";
 import { InteractionRequiredAuthError } from "@azure/msal-browser";
 import type { useMetadata } from "@/hooks/use-metadata";
 import { DeleteMetadataModal } from "@/components/delete-metadata-modal";
+import type React from "react";
 
 export async function getConfig(): Promise<FriskConfig> {
 	const schemas = await getSchemasFromRegelrett();
@@ -178,13 +181,26 @@ export async function getConfig(): Promise<FriskConfig> {
 						});
 						const url = `${getregelrettFrontendUrl()}/context/${contextId}?${searchParams.toString()}`;
 						//Check if the context exists in regelrett and delete metadata if it does not exist
-						try {
-							await fetchFromRegelrett(`contexts/${contextId}`);
-						} catch (error) {
+						const response = await fetchFromRegelrett(`contexts/${contextId}`);
+						if (response.status === 404) {
 							await deleteFunctionMetadata(input.id);
 							return { displayValue: undefined };
 						}
-
+						if (response.status === 403) {
+							return {
+								displayValue: schema.name,
+								displayOptions: {
+									type: "custom",
+									component: (
+										<Flex width="90%" gap={2} alignItems="center">
+											<Icon size={20} icon="article" />
+											<Text fontSize={"sm"}>{schema.name}</Text>
+											<Icon size={16} icon="lock" isFilled />
+										</Flex>
+									),
+								},
+							};
+						}
 						return {
 							displayValue: schema.name,
 							displayOptions: {
@@ -541,18 +557,20 @@ async function getRegelrettTokens() {
 }
 
 async function fetchFromRegelrett(path: string, options: RequestInit = {}) {
-	const tokens = await getRegelrettTokens();
-	const response = await fetch(`${REGELRETT_BACKEND_URL}/${path}`, {
-		...options,
-		headers: {
-			...options.headers,
-			Authorization: `Bearer ${tokens.accessToken}`,
-		},
-	});
-	if (!response.ok) {
-		throw new Error(`Backend error: ${response.status} ${response.statusText}`);
+	try {
+		const tokens = await getRegelrettTokens();
+		const response = await fetch(`${REGELRETT_BACKEND_URL}/${path}`, {
+			...options,
+			headers: {
+				...options.headers,
+				Authorization: `Bearer ${tokens.accessToken}`,
+			},
+		});
+		return response;
+	} catch (error) {
+		console.error("Fetch from Regelrett error:", error);
+		throw error;
 	}
-	return response;
 }
 
 export async function createRegelrettContext({

--- a/frisk.config.tsx
+++ b/frisk.config.tsx
@@ -20,6 +20,7 @@ import {
 	Select,
 	useDisclosure,
 	Text,
+	Tooltip,
 } from "@kvib/react";
 import type { useFunction } from "@/hooks/use-function";
 import { msalInstance } from "@/services/msal";
@@ -192,11 +193,13 @@ export async function getConfig(): Promise<FriskConfig> {
 								displayOptions: {
 									type: "custom",
 									component: (
-										<Flex width="90%" gap={2} alignItems="center">
-											<Icon size={20} icon="article" />
-											<Text fontSize={"sm"}>{schema.name}</Text>
-											<Icon size={16} icon="lock" isFilled />
-										</Flex>
+										<Tooltip label="Brukeren din har ikke tilgang til denne funksjonen, derfor kan du ikke se eller endre sikkerhetsskjema for den.">
+											<Flex width="90%" gap={2} alignItems="center" as="span">
+												<Icon size={20} icon="article" />
+												<Text fontSize={"sm"}>{schema.name}</Text>
+												<Icon size={16} icon="lock" isFilled />
+											</Flex>
+										</Tooltip>
 									),
 								},
 							};
@@ -369,14 +372,23 @@ type FunctionCardComponentProps = {
 	func: ReturnType<typeof useFunction>["func"];
 	metadata: ReturnType<typeof useMetadata>["metadata"];
 	addMetadata: ReturnType<typeof useMetadata>["addMetadata"];
+	hasAccess: boolean;
 };
 
 function createSchemaComponent(schemas: RegelrettSchema[]) {
-	return ({ func, metadata, addMetadata }: FunctionCardComponentProps) => {
+	return ({
+		func,
+		metadata,
+		addMetadata,
+		hasAccess,
+	}: FunctionCardComponentProps) => {
 		const [selectedSchema, setSelectedSchema] = useState("");
 		const availableSchemas = schemas.filter(
 			(schema) => !metadata.data?.find((m) => m.key === schema.id),
 		);
+
+		if (availableSchemas.length < 1) return;
+		if (!hasAccess) return;
 		return (
 			<form
 				onSubmit={async (e) => {
@@ -402,7 +414,7 @@ function createSchemaComponent(schemas: RegelrettSchema[]) {
 					});
 				}}
 			>
-				<FormControl isRequired={true} style={{ width: "fit-content" }}>
+				<FormControl style={{ width: "fit-content" }}>
 					<FormLabel style={{ fontSize: "14px" }}>
 						Opprett sikkerhetsskjema
 					</FormLabel>

--- a/frisk.config.tsx
+++ b/frisk.config.tsx
@@ -196,8 +196,10 @@ export async function getConfig(): Promise<FriskConfig> {
 										<Tooltip label="Brukeren din har ikke tilgang til denne funksjonen, derfor kan du ikke se eller endre sikkerhetsskjema for den.">
 											<Flex width="90%" gap={2} alignItems="center" as="span">
 												<Icon size={20} icon="article" />
-												<Text fontSize={"sm"}>{schema.name}</Text>
-												<Icon size={16} icon="lock" isFilled />
+												<Flex alignItems="center">
+													<Text fontSize={"sm"}>{schema.name}</Text>
+													<Icon size={16} icon="lock" isFilled />
+												</Flex>
 											</Flex>
 										</Tooltip>
 									),

--- a/src/components/function-card-selected-view.tsx
+++ b/src/components/function-card-selected-view.tsx
@@ -12,7 +12,7 @@ export function FunctionCardSelectedView({
 	functionId,
 }: { functionId: number }) {
 	const { func } = useFunction(functionId);
-	const { metadata, addMetadata } = useMetadata(functionId);
+	const { metadata, addMetadata, metadataAccess } = useMetadata(functionId);
 	const { config } = Route.useLoaderData();
 	const [showCopiedTextMessage, setShowCopiedTextMessage] = useState(false);
 	const search = Route.useSearch();
@@ -58,6 +58,7 @@ export function FunctionCardSelectedView({
 					func={func}
 					metadata={metadata}
 					addMetadata={addMetadata}
+					hasAccess={!!metadataAccess}
 				/>
 			))}
 			{!showCopiedTextMessage ? (

--- a/src/components/metadata/metadata-value.tsx
+++ b/src/components/metadata/metadata-value.tsx
@@ -51,7 +51,7 @@ export function MetadataValue({ metadata, functionId }: Props) {
 	}
 
 	return (
-		<Box my={1}>
+		<Box mb={1}>
 			{displayValues.map((dv, i) => {
 				const isDisplayValueLoading = dv.isLoading;
 				const metaDataValue = dv.data?.value ?? metadataToDisplay?.[i]?.value;


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Bytte ut uid visningen ved manglende tilgang på skjema med tydligere visning. Også fikse lette-spørringen som sletter skjemane i metadata databsen til frisk hvis regelrett sende rnoe annet enn 200. 

**Løsning**

🆕 Endring: 
Skjemaer slettes fra frisk på 404 feil fra regelrett - altså at skejamet ikke finnes i regelrett.
Ved 403 feil vises egen visning på skjemaer: 
![image](https://github.com/user-attachments/assets/0dcb2f65-5ac6-4839-999a-1fa474f872ee)

I tilleg vises ikke opprett-skjema bolken hvis man ikke har tilgang, og hvis alle skjemane for det funksjonen allerede er opprettet:

![image](https://github.com/user-attachments/assets/a4680b2d-a527-43d4-bc3e-03c690e1c118)

Også er margin-topp fjernet mellom metadata innhold og overskrift etter skisser. 
