### PR TITLE
Indicator med value returnerer ingenting

### DIFF
--- a/src/components/indicator-pointer.tsx
+++ b/src/components/indicator-pointer.tsx
@@ -24,7 +24,12 @@ export function IndicatorPointer({
 			? {
 					functionId,
 					key: indicatorMetadataKey.key,
-					value: indicatorMetadataKey.value as string,
+					value:
+						indicatorMetadataKey.value &&
+						typeof indicatorMetadataKey.value === "object" &&
+						"value" in indicatorMetadataKey.value
+							? (indicatorMetadataKey.value.value as string)
+							: undefined,
 				}
 			: undefined,
 	);


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Fikse indikatorløsningen slik at når man velger feks spesefikt team vises dette riktig. pe rnå vises ingenting hvis man velger med value på indikatorer.

**Løsning**

🆕 Endring: 
Problemet lå i at valuen lå i value.value, men useIndicator sendte med value som streng, og fikk ikke da med seg den faktisk valuen på indikatorere som den skal spørre backenden om.
