### PR TITLE
conditional title display

### DIFF
--- a/src/components/metadata/metadata-view.tsx
+++ b/src/components/metadata/metadata-view.tsx
@@ -1,6 +1,7 @@
 import { Flex, Text } from "@kvib/react";
 import type { Metadata } from "frisk.config";
 import { MetadataValue } from "./metadata-value";
+import { Route } from "@/routes";
 
 export function MetadataView({
 	metadataConfig,
@@ -9,9 +10,17 @@ export function MetadataView({
 	metadataConfig: Metadata;
 	functionId: number;
 }) {
+	const { config } = Route.useLoaderData();
+	const ducplicateTitleAlreadyDisplayed = config.metadata
+		?.slice(
+			0,
+			config.metadata.findIndex((meta) => meta === metadataConfig),
+		)
+		.some((meta) => meta.title === metadataConfig.title);
+
 	return (
 		<Flex key={metadataConfig.key} flexDirection="column">
-			{metadataConfig.title && (
+			{metadataConfig.title && !ducplicateTitleAlreadyDisplayed && (
 				<Text fontSize="sm" fontWeight="700">
 					{metadataConfig.title}:
 				</Text>


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Redusere overskrifter til en per sikkerhetsskjema:
før
![image](https://github.com/user-attachments/assets/0175dc62-3860-4756-a2bd-5733ec30f455)
etter
![image](https://github.com/user-attachments/assets/d7e06499-0185-4e65-b191-e26657173cd9)


**Løsning**

🆕 Endring: 
Lagt til sjekk på display av tittler. Hvis det ligger en metadata i listen forran den metadataen som skal displayes med samme tittel, så vises ikke tittel. 

