### PR TITLE
359 fjern automatisk sletting av skjema

### DIFF
--- a/frisk.config.tsx
+++ b/frisk.config.tsx
@@ -233,7 +233,7 @@ export async function getConfig(): Promise<FriskConfig> {
 		},
 		title: "Funksjonsregisteret",
 		description:
-			"Smell opp noen bra funksjoner og få den oversikten du fortjener",
+			"Funksjonsregisteret (FRISK) lar deg visualisere funksjoner i et hierarki. Her kan man blant annet definere kritikalitet, ansvarlig team og avhengigheter. Du kan også opprette sikkerhetsskjemaer koblet til Regelrett.",
 		rootNodeName: "Kartverket",
 		columnName: "Funksjon",
 		addButtonName: "Legg til funksjon",

--- a/frisk.config.tsx
+++ b/frisk.config.tsx
@@ -181,11 +181,14 @@ export async function getConfig(): Promise<FriskConfig> {
 							redirectBackTitle: "Funksjonsregisteret",
 						});
 						const url = `${getregelrettFrontendUrl()}/context/${contextId}?${searchParams.toString()}`;
-						//Check if the context exists in regelrett and delete metadata if it does not exist
 						const response = await fetchFromRegelrett(`contexts/${contextId}`);
 						if (response.status === 404) {
-							await deleteFunctionMetadata(input.id);
-							return { displayValue: undefined };
+							return { displayValue: schema.name, displayOptions: {
+								type: "custom",
+								component: (
+									<SchemaNotFoundDisplay schema={schema} functionId={input.functionId} metadataId={input.id}/>
+								)
+							} };
 						}
 						if (response.status === 403) {
 							return {
@@ -195,7 +198,7 @@ export async function getConfig(): Promise<FriskConfig> {
 									component: (
 										<Tooltip label="Brukeren din har ikke tilgang til denne funksjonen, derfor kan du ikke se eller endre sikkerhetsskjema for den.">
 											<Flex width="90%" gap={2} alignItems="center" as="span">
-												<Icon size={20} icon="article" />
+												<Icon icon="article" />
 												<Flex alignItems="center">
 													<Text fontSize={"sm"}>{schema.name}</Text>
 													<Icon size={16} icon="lock" isFilled />
@@ -463,6 +466,7 @@ type SchemaDisplayProps = {
 	metadataId: number;
 };
 
+
 function SchemaDisplay({
 	schema,
 	url,
@@ -498,7 +502,7 @@ function SchemaDisplay({
 				aria-label="Delete schema"
 				icon="delete"
 				variant="tertiary"
-				size="sm"
+				size="xs"
 				colorScheme="red"
 				borderRadius="md"
 				_hover={{ backgroundColor: "red.50" }}
@@ -517,6 +521,45 @@ function SchemaDisplay({
 			/>
 		</Flex>
 	);
+}
+
+type SchemaNotFoundDisplayProps = Omit<SchemaDisplayProps, "url">
+
+function SchemaNotFoundDisplay({schema, functionId, metadataId}: SchemaNotFoundDisplayProps) {
+	const { isOpen, onOpen, onClose } = useDisclosure();
+
+	return (
+		<Flex gap={2} alignItems="center">
+			<Tooltip label="Vi klarte ikke å finne dette sikkerhetsskjemaet i Regelrett. Vanligvis skyldes det at skjemaet har blitt slettet der. Hvis du vet det stemmer, er det trygt å slette det her også.">
+				<Flex gap={2} alignItems="center">
+					<Icon icon="warning" isFilled={true} color="var(--kvib-colors-orange-600)"/>
+					<Icon size={20} icon="article" />
+					<Text>{schema.name}</Text>
+				</Flex>
+			</Tooltip>
+			<IconButton 
+				aria-label="Delete schema"
+				icon="delete"
+				variant="tertiary"
+				size="xs"
+				colorScheme="red"
+				borderRadius="md"
+				_hover={{ backgroundColor: "red.50" }}
+				onClick={(e) => {
+					e.stopPropagation();
+					onOpen();
+				}}
+			/>
+			<DeleteMetadataModal
+				onOpen={onOpen}
+				onClose={onClose}
+				isOpen={isOpen}
+				functionId={functionId}
+				metadataId={metadataId}
+				displayValue={schema.name}
+			/>
+		</Flex>
+	)
 }
 
 const REGELRETT_BACKEND_URL = `${getregelrettFrontendUrl()}/api`;

--- a/frisk.config.tsx
+++ b/frisk.config.tsx
@@ -21,6 +21,7 @@ import {
 	useDisclosure,
 	Text,
 	Tooltip,
+	useToast,
 } from "@kvib/react";
 import type { useFunction } from "@/hooks/use-function";
 import { msalInstance } from "@/services/msal";
@@ -529,12 +530,12 @@ function SchemaNotFoundDisplay({schema, functionId, metadataId}: SchemaNotFoundD
 	const { isOpen, onOpen, onClose } = useDisclosure();
 
 	return (
-		<Flex gap={2} alignItems="center">
+		<Flex width="90%" gap={2} alignItems="center">
 			<Tooltip label="Vi klarte ikke å finne dette sikkerhetsskjemaet i Regelrett. Vanligvis skyldes det at skjemaet har blitt slettet der. Hvis du vet det stemmer, er det trygt å slette det her også.">
 				<Flex gap={2} alignItems="center">
 					<Icon icon="warning" isFilled={true} color="var(--kvib-colors-orange-600)"/>
 					<Icon size={20} icon="article" />
-					<Text>{schema.name}</Text>
+					<Text fontSize="sm">{schema.name}</Text>
 				</Flex>
 			</Tooltip>
 			<IconButton 

--- a/frisk.config.tsx
+++ b/frisk.config.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import {
-	deleteFunctionMetadata,
 	getFunction,
 	getFunctionMetadata,
 	getFunctions,
@@ -21,7 +20,6 @@ import {
 	useDisclosure,
 	Text,
 	Tooltip,
-	useToast,
 } from "@kvib/react";
 import type { useFunction } from "@/hooks/use-function";
 import { msalInstance } from "@/services/msal";

--- a/src/components/delete-metadata-modal.tsx
+++ b/src/components/delete-metadata-modal.tsx
@@ -60,6 +60,7 @@ export function DeleteMetadataModal({
 									id: metadataId,
 									functionId: functionId,
 									key: metadataToDelete?.key ?? "",
+									displayValue: displayValue,
 								});
 							}}
 							isLoading={removeMetadata.isPending}

--- a/src/components/function-column-view.tsx
+++ b/src/components/function-column-view.tsx
@@ -126,7 +126,7 @@ export function FunctionColumnView({ path }: FunctionColumnViewProps) {
 			<Text fontSize="2xl" fontWeight="700" marginBottom="3">
 				{config.title}
 			</Text>
-			<Text fontSize="xs" marginBottom="38">
+			<Text fontSize="sm" marginBottom="38">
 				{config.description}
 			</Text>
 			<Button

--- a/src/hooks/use-metadata.ts
+++ b/src/hooks/use-metadata.ts
@@ -103,15 +103,27 @@ export function useMetadata(functionId: number | undefined) {
 			id: number;
 			functionId: number;
 			key: string;
+			displayValue?: string;
 		}) => {
+			const toastId = "delete-metadata";
 			try {
 				(await getConfig()).metadata
 					?.find((m) => m.key === args.key)
 					?.onDelete?.({ id: args.id, functionId: args.functionId });
 				await deleteFunctionMetadata(args.id);
+				if (!toast.isActive(toastId)) {
+					toast({
+						id: toastId,
+						description: args.displayValue
+							? `Sikkerhetsskjemaet ${args.displayValue} ble slettet.`
+							: "Sikkerhetsskjemaet ble slettet.",
+						status: "success",
+						duration: 5000,
+						isClosable: true,
+					});
+				}
 			} catch (error) {
 				console.error("Error deleting metadata: ", error);
-				const toastId = "delete-metadata";
 				if (!toast.isActive(toastId)) {
 					toast({
 						id: toastId,

--- a/src/hooks/use-metadata.ts
+++ b/src/hooks/use-metadata.ts
@@ -115,8 +115,8 @@ export function useMetadata(functionId: number | undefined) {
 					toast({
 						id: toastId,
 						description: args.displayValue
-							? `Sikkerhetsskjemaet ${args.displayValue} ble slettet.`
-							: "Sikkerhetsskjemaet ble slettet.",
+							? `Slettet ${args.displayValue}.`
+							: "Slettet metadata.",
 						status: "success",
 						duration: 5000,
 						isClosable: true,


### PR DESCRIPTION
**Beskrivelse**

Fjerner automatisk sletting av skjemaer i FRISK hvis de ikke lenger finnes i Regelrett.

**Løsning**

Nå vises det et ikon med tooltip som sier at skjemaet har blitt slettet i Regelrett, så må man heller manuelt slette skjemaet i FRISK.

