### PR TITLE
Feat klikkbar funksjonsavhengighet

### DIFF
--- a/src/components/metadata/metadata-value.tsx
+++ b/src/components/metadata/metadata-value.tsx
@@ -1,6 +1,7 @@
 import { useMetadata } from "@/hooks/use-metadata";
 import {
 	Box,
+	Button,
 	Flex,
 	IconButton,
 	Link,
@@ -13,6 +14,7 @@ import { useQueries } from "@tanstack/react-query";
 import type { Metadata } from "../../../frisk.config";
 import { DeleteMetadataModal } from "../delete-metadata-modal";
 import TextareaAutosize from "react-textarea-autosize";
+import { Route } from "@/routes";
 
 type Props = {
 	metadata: Metadata;
@@ -90,6 +92,7 @@ export function MetadataValue({ metadata, functionId }: Props) {
 							<PillView
 								key={metaDataValue}
 								displayValue={dv.data.displayValue}
+								funcPath={dv.data.displayOptions.path}
 								isLoading={isLoading}
 							/>
 						);
@@ -247,24 +250,55 @@ function LinkView({
 
 type PillViewProps = {
 	displayValue: string | undefined;
+	funcPath: string;
 	isLoading: boolean;
 };
 
-function PillView({ displayValue, isLoading }: PillViewProps) {
+function PillView({ displayValue, funcPath, isLoading }: PillViewProps) {
+	const search = Route.useSearch();
+	const navigate = Route.useNavigate();
 	return (
 		<Skeleton isLoaded={!isLoading} fitContent>
-			<Box
-				bg="#BAD7F8"
-				paddingRight={1}
-				paddingLeft={1}
-				borderRadius="md"
-				w="fit-content"
-				my={1}
+			<Button
+				variant="ghost"
+				padding={0}
+				margin={0}
+				minWidth={0}
+				height="auto"
+				onClick={(e) => {
+					e.stopPropagation();
+					const filteredPath = search.path.filter(
+						(path) => !funcPath.startsWith(path),
+					);
+					const newPath = filteredPath.includes(funcPath)
+						? filteredPath
+						: [...filteredPath, funcPath];
+					navigate({
+						search: {
+							...search,
+							path: newPath,
+						},
+					});
+				}}
 			>
-				<Text fontSize="sm" fontWeight="500">
-					{displayValue ?? "<Ingen verdi>"}
-				</Text>
-			</Box>
+				<Box
+					bg="#BAD7F8"
+					paddingRight={1}
+					paddingLeft={1}
+					borderRadius="md"
+					w="fit-content"
+					my={1}
+					transition="box-shadow 0.2s"
+					_hover={{
+						boxShadow: "md",
+						cursor: "pointer",
+					}}
+				>
+					<Text fontSize="sm" fontWeight="500">
+						{displayValue ?? "<Ingen verdi>"}
+					</Text>
+				</Box>
+			</Button>
 		</Skeleton>
 	);
 }

--- a/src/components/metadata/metadata-value.tsx
+++ b/src/components/metadata/metadata-value.tsx
@@ -277,6 +277,7 @@ function PillView({ displayValue, funcPath, isLoading }: PillViewProps) {
 						search: {
 							...search,
 							path: newPath,
+							highlighted: Number(funcPath.split(".").slice(-1)[0] ?? "1"),
 						},
 					});
 				}}


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 

Kunne bruke Frisk til virksomhetsarkitektur
For å kunne bruke frisk til mer enn bare en funksjonsregister ønsker man bedre løsning for å bli sendt til den avhengigheten en funksjon har ved klikk. 

**Løsning**

🆕 Endring: 

- Funksjonsavhengighet -> avhengighet
- Avhengigheter er klikkbare og navigerer til den stien som tilhører avhengigheten, åpner opp kortet og setter en highlighted border


<img width="388" height="183" alt="image" src="https://github.com/user-attachments/assets/b099844c-ce12-485d-b371-78252102dc3b" />


<img width="1526" height="1195" alt="image" src="https://github.com/user-attachments/assets/2413d5ba-e71e-4e59-bfeb-d50b0380cf51" />


- I tillegg har jeg sidestilt knappen til å opprette funksjonsregister og gjort inputfeltet mer klikkbart.

