### PR TITLE
Dnd sortering på kolonner

### DIFF
--- a/src/components/buttons/select-button.tsx
+++ b/src/components/buttons/select-button.tsx
@@ -13,7 +13,11 @@ export function SelectButton({
 	});
 
 	return (
-		<Droppable groupId={functionId} droppableId={`${functionId}-self`}>
+		<Droppable
+			groupId={functionId}
+			droppableId={`${functionId}-self`}
+			orderIndex={children.data?.length ?? 0}
+		>
 			{({ isOver, setNodeRef }) => (
 				<Flex
 					border="1px"

--- a/src/components/droppable.tsx
+++ b/src/components/droppable.tsx
@@ -3,17 +3,24 @@ import { useDroppable } from "@dnd-kit/core";
 type DroppableProps = {
 	groupId: number;
 	droppableId: string;
+	orderIndex: number;
 	children: (props: {
 		isOver: boolean;
 		setNodeRef: (element: HTMLElement | null) => void;
 	}) => React.ReactNode;
 };
 
-export function Droppable({ groupId, droppableId, children }: DroppableProps) {
+export function Droppable({
+	groupId,
+	orderIndex,
+	droppableId,
+	children,
+}: DroppableProps) {
 	const { setNodeRef, over } = useDroppable({
 		id: droppableId,
 		data: {
 			group: groupId,
+			order: orderIndex,
 		},
 	});
 

--- a/src/components/function-column-view.tsx
+++ b/src/components/function-column-view.tsx
@@ -55,11 +55,7 @@ export function FunctionColumnView({ path }: FunctionColumnViewProps) {
 
 	async function handleDragEnd(event: DragEndEvent) {
 		const { active, over } = event;
-		if (
-			active.data.current &&
-			over?.data.current &&
-			active.data.current.func.parentId !== Number(over.data.current.group)
-		) {
+		if (active.data.current && over?.data.current) {
 			const update = active.data.current.update as ReturnType<
 				typeof useFunction
 			>["updateFunction"];
@@ -67,6 +63,7 @@ export function FunctionColumnView({ path }: FunctionColumnViewProps) {
 			const updatedFunc = await update.mutateAsync({
 				...active.data.current.func,
 				parentId: Number(over.data.current.group),
+				orderIndex: over.data.current.order,
 			});
 
 			if (!selectedFunctionIds.flat().includes(over.data.current.group)) {

--- a/src/components/function-column.tsx
+++ b/src/components/function-column.tsx
@@ -199,7 +199,7 @@ function ChildrenGroup({
 										droppableId={child.id.toString()}
 										orderIndex={i}
 									>
-										{({ isOver, setNodeRef }) => (
+										{({ setNodeRef }) => (
 											<Box
 												ref={setNodeRef}
 												paddingTop={3}

--- a/src/components/function-column.tsx
+++ b/src/components/function-column.tsx
@@ -178,37 +178,51 @@ function ChildrenGroup({
 				left={0}
 				right={0}
 			>
-				<Droppable groupId={functionId} droppableId={functionId.toString()}>
+				<Droppable
+					groupId={functionId}
+					droppableId={`${functionId}-last`}
+					orderIndex={sortedChildren?.length ?? 0}
+				>
 					{({ isOver, setNodeRef }) => (
 						<Box
-							padding={"8px"}
 							backgroundColor={isOver ? "blue.100" : "gray.200"}
 							borderRadius="md"
 							border="1px"
 							marginBottom={2}
 							ref={setNodeRef}
 						>
-							<List
-								display="flex"
-								flexDirection="column"
-								gap={2}
-								marginBottom="2"
-							>
-								{sortedChildren?.map((child) => (
-									<ChildrenGroupItem
-										key={child.id + child.name + child.parentId}
-										func={child}
-										selected={selectedFunctionIds.some((idList) =>
-											idList.includes(child.id),
+							<List display="flex" flexDirection="column" marginBottom="2">
+								{sortedChildren?.map((child, i) => (
+									<Droppable
+										key={child.id}
+										groupId={functionId}
+										droppableId={child.id.toString()}
+										orderIndex={i}
+									>
+										{({ isOver, setNodeRef }) => (
+											<Box
+												ref={setNodeRef}
+												paddingTop={3}
+												paddingX="8px"
+												borderRadius="md"
+											>
+												<ChildrenGroupItem
+													key={child.id + child.name + child.parentId}
+													func={child}
+													selected={selectedFunctionIds.some((idList) =>
+														idList.includes(child.id),
+													)}
+													lowLighted={
+														!!filters &&
+														!hasAllMetadataInFilter.find(
+															(item) => item.functionId === child.id,
+														)?.hasAllMetadataInFilter
+													}
+													isLoading={metadataIsLoading}
+												/>
+											</Box>
 										)}
-										lowLighted={
-											!!filters &&
-											!hasAllMetadataInFilter.find(
-												(item) => item.functionId === child.id,
-											)?.hasAllMetadataInFilter
-										}
-										isLoading={metadataIsLoading}
-									/>
+									</Droppable>
 								))}
 							</List>
 							<Button
@@ -218,6 +232,7 @@ function ChildrenGroup({
 								onClick={() => {
 									setSelectedForm(functionId);
 								}}
+								marginBottom={"8px"}
 							>
 								{config.addButtonName}
 							</Button>


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Å kunne sortere rekkefølge på funksjonskortene med drag and drop. 

**Løsning**

🆕 Endring: 

Hver funksjon har en ekstra droppable-sone rundt seg med padding over med tilhørende orderindex - slik at orderindex til den droppableen blir sendt inn til funksjonen du flytter på. 

