### PR TITLE
Fix: Eksporter alle teamnavn som csv

### DIFF
--- a/src/components/function-column-view.tsx
+++ b/src/components/function-column-view.tsx
@@ -15,7 +15,7 @@ import {
 	useSensors,
 } from "@dnd-kit/core";
 import type { useFunction } from "@/hooks/use-function";
-import { getFunctionsCSVDump } from "@/services/backend";
+import { getFunctionsCSVDump, getMyMicrosoftTeams } from "@/services/backend";
 import { Route } from "@/routes";
 import { SearchField } from "./search-field";
 import { FunctionCard } from "./function-card";
@@ -32,6 +32,7 @@ export function FunctionColumnView({ path }: FunctionColumnViewProps) {
 	const selectedFunctionIds = getIdsFromPath(path);
 	const navigate = Route.useNavigate();
 	const search = Route.useSearch();
+	const downloadTeamNames = true;
 
 	const sensors = useSensors(
 		useSensor(MouseSensor, {
@@ -82,6 +83,33 @@ export function FunctionColumnView({ path }: FunctionColumnViewProps) {
 	const handleExportCSV = async () => {
 		try {
 			const csvData = await getFunctionsCSVDump();
+
+			if (downloadTeamNames) {
+				const teamCSVdata = await getMyMicrosoftTeams();
+
+				const csvRows = [];
+
+				csvRows.push(["id", "displayName"]);
+				teamCSVdata.forEach((value) => {
+					csvRows.push([value.id, value.displayName]);
+				});
+
+				let csvContent = "";
+
+				csvRows.forEach((row) => {
+					csvContent += `${row.join(",")}\n`;
+				});
+				const teamBlob = new Blob([csvContent], {
+					type: "text/csv;charset=utf-8,",
+				});
+				const objUrl = URL.createObjectURL(teamBlob);
+				const teamLink = document.createElement("a");
+				teamLink.setAttribute("href", objUrl);
+				teamLink.setAttribute("download", "teamNames.csv");
+				document.body.appendChild(teamLink);
+				teamLink.click();
+				document.body.removeChild(teamLink);
+			}
 
 			if (!csvData) {
 				throw new Error("No data received for CSV");

--- a/src/components/function-column-view.tsx
+++ b/src/components/function-column-view.tsx
@@ -15,7 +15,7 @@ import {
 	useSensors,
 } from "@dnd-kit/core";
 import type { useFunction } from "@/hooks/use-function";
-import { getFunctionsCSVDump, getMyMicrosoftTeams } from "@/services/backend";
+import { getAllMicrosoftTeams, getFunctionsCSVDump } from "@/services/backend";
 import { Route } from "@/routes";
 import { SearchField } from "./search-field";
 import { FunctionCard } from "./function-card";
@@ -85,7 +85,7 @@ export function FunctionColumnView({ path }: FunctionColumnViewProps) {
 			const csvData = await getFunctionsCSVDump();
 
 			if (downloadTeamNames) {
-				const teamCSVdata = await getMyMicrosoftTeams();
+				const teamCSVdata = await getAllMicrosoftTeams();
 
 				const csvRows = [];
 

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -223,6 +223,14 @@ export async function getMyMicrosoftTeams() {
 	return array(MicrosoftTeam).parse(json);
 }
 
+export async function getAllMicrosoftTeams(){
+	const response = await fetchFromBackend("/microsoft/allTeams", {
+		method: "GET",
+	});
+	const json = await response.json();
+	return array(MicrosoftTeam).parse(json);
+}
+
 export async function getTeam(id: string) {
 	const response = await fetchFromBackend(`/microsoft/teams/${id}`, {
 		method: "GET",


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 

Tidligere eksportertes kun teamnavn til team bruker var en del av. Ønskelig å eksportere _alle_ teamnavn.

**Løsning**

🆕 Endring: 
Bruker nytt endepunkt som henter alle teamnavn fra entra-id. 

**🧪 Testing**

Sjekk at alle teamnavn dukker opp i csv-filen. 

🔒 **Sikkerhet / Trusselvurdering**

Alle teamnavnene blir vist. 


