### PR TITLE
Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,12 +1,11 @@
-# nonk8s
-apiVersion: "backstage.io/v1alpha1"
-kind: "Component"
+apiVersion: backstage.io/v1alpha1
+kind: Component
 metadata:
-  name: "frisk-frontend"
+  name: frisk-frontend
   tags:
-  - "internal"
+    - internal
 spec:
-  type: "website"
-  lifecycle: "production"
-  owner: "skvis"
-  system: "funksjon-skjema-register"
+  type: website
+  lifecycle: deprecated
+  owner: skvis
+  system: system:default/funksjon-skjema-register


### PR DESCRIPTION
catalog-info.yaml has been updated

        
        

        
        

        All entities in catalog-info.yaml:
        name: frisk-frontend, kind: Component 
        
        

 This PR was created using the Catalog Creator plugin in Backstage.